### PR TITLE
Remove canonical options underlyings handling

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1656,7 +1656,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 _subscribedSymbols.Clear();
                 _subscribedTickers.Clear();
-                _underlyings.Clear();
             }
 
             Subscribe(subscribedSymbols);
@@ -2862,13 +2861,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                             // processing canonical option and futures symbols
                             var subscribeSymbol = symbol;
 
-                            // we subscribe to the underlying
-                            if (symbol.ID.SecurityType.IsOption() && symbol.IsCanonical())
-                            {
-                                subscribeSymbol = symbol.Underlying;
-                                _underlyings.Add(subscribeSymbol, symbol);
-                            }
-
                             // we ignore futures canonical symbol
                             if (symbol.ID.SecurityType == SecurityType.Future && symbol.IsCanonical())
                             {
@@ -2938,11 +2930,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         lock (_sync)
                         {
                             Log.Trace($"InteractiveBrokersBrokerage.Unsubscribe(): Unsubscribe Request: {symbol.Value}. SubscribedSymbols.Count: {_subscribedSymbols.Count}");
-
-                            if (symbol.ID.SecurityType.IsOption() && symbol.ID.StrikePrice == 0.0m)
-                            {
-                                _underlyings.Remove(symbol.Underlying);
-                            }
 
                             int id;
                             if (_subscribedSymbols.TryRemove(symbol, out id))
@@ -3257,13 +3244,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 };
 
                 _aggregator.Update(tick);
-
-                if (_underlyings.ContainsKey(tick.Symbol))
-                {
-                    var underlyingTick = tick.Clone() as Tick;
-                    underlyingTick.Symbol = _underlyings[tick.Symbol];
-                    _aggregator.Update(underlyingTick);
-                }
             }
         }
 
@@ -3879,7 +3859,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
         private readonly ConcurrentDictionary<Symbol, int> _subscribedSymbols = new ConcurrentDictionary<Symbol, int>();
         private readonly ConcurrentDictionary<int, SubscriptionEntry> _subscribedTickers = new ConcurrentDictionary<int, SubscriptionEntry>();
-        private readonly Dictionary<Symbol, Symbol> _underlyings = new Dictionary<Symbol, Symbol>();
 
         private class SubscriptionEntry
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- For some time now, if the symbol is canonical we do not subscribe see 'CanSubscribe()'. Removing related logic which is no longer used. https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/blob/master/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs#L2987

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clean up
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
IB live deployments subscribing to option chains
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
