### PR TITLE
Check if connected before processing open order

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1942,6 +1942,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 Log.Trace($"InteractiveBrokersBrokerage.HandleOpenOrder(): {e}");
 
+                if (!CheckIfConnected())
+                {
+                    // before we call get open orders which might not be fully initialized/loaded
+                    return;
+                }
+
                 var orders = _orderProvider.GetOrdersByBrokerageId(e.Order.OrderId);
                 if (orders == null || orders.Count == 0)
                 {
@@ -1952,11 +1958,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // the only changes we handle now are trail stop price updates
                 var order = orders[0];
                 if (order.Type != OrderType.TrailingStop)
-                {
-                    return;
-                }
-
-                if (!CheckIfConnected())
                 {
                     return;
                 }


### PR DESCRIPTION
- Check if connected before processing open order, avoid null reference

See https://github.com/QuantConnect/Lean/pull/7468

<img width="1842" alt="image" src="https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/assets/18473240/abb03a9e-b36b-4446-a8d9-4aa0efa3acd6">
