### PR TITLE
Fixes Mapping Bug For Option Underlying with Space in Ticker

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersSymbolMapperTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersSymbolMapperTests.cs
@@ -55,6 +55,15 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.AreEqual("BRK.B", symbol.Value);
             Assert.AreEqual(SecurityType.Equity, symbol.ID.SecurityType);
             Assert.AreEqual(Market.USA, symbol.ID.Market);
+
+            var expiry = new DateTime(2023, 10, 20);
+            symbol = mapper.GetLeanSymbol("BRK B", SecurityType.Option, Market.USA, expiry, 362.5m, OptionRight.Put);
+            Assert.AreEqual("BRK.B 231020P00362500", symbol.Value);
+            Assert.AreEqual(SecurityType.Option, symbol.ID.SecurityType);
+            Assert.AreEqual(Market.USA, symbol.ID.Market);
+            Assert.AreEqual(362.5m, symbol.ID.StrikePrice);
+            Assert.AreEqual(expiry, symbol.ID.Date);
+            Assert.AreEqual(OptionRight.Put, symbol.ID.OptionRight);
         }
 
         [Test]

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersSymbolMapper.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersSymbolMapper.cs
@@ -158,6 +158,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         return Symbol.CreateFuture(GetLeanRootSymbol(brokerageSymbol), market, expirationDate);
 
                     case SecurityType.Option:
+                        // See SecurityType.Equity case. The equity underlying may include a space, e.g. BRK B. 
+                        brokerageSymbol = brokerageSymbol.Replace(" ", ".");
                         return Symbol.CreateOption(brokerageSymbol, market, OptionStyle.American, optionRight, strike, expirationDate);
 
                     case SecurityType.IndexOption:


### PR DESCRIPTION
#### Description
Adds a unit test to reproduce the mapping bug.

#### Related Issue
Closes #85

#### Motivation and Context
Bug.

#### How Has This Been Tested?
New unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`