### PR TITLE
Return null on unsupported history requests

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.ToolBox/IBDataDownloader.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.ToolBox/IBDataDownloader.cs
@@ -99,7 +99,15 @@ namespace QuantConnect.ToolBox.IBDownloader
                     DataNormalizationMode.Adjusted,
                     TickType.Quote);
 
-                foreach (var baseData in _brokerage.GetHistory(historyRequest))
+                var history = _brokerage.GetHistory(historyRequest);
+
+                if (history == null)
+                {
+                    Logging.Log.Trace($"IBDataDownloader.Get(): Ignoring history request for unsupported symbol {targetSymbol}");
+                    continue;
+                }
+
+                foreach (var baseData in history)
                 {
                     yield return baseData;
                 }

--- a/QuantConnect.InteractiveBrokersBrokerage.ToolBox/IBDownloaderProgram.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.ToolBox/IBDownloaderProgram.cs
@@ -87,6 +87,10 @@ namespace QuantConnect.ToolBox.IBDownloader
                         while (startDate < auxEndDate)
                         {
                             var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, startDate, auxEndDate, TickType.Quote));
+                            if (data == null)
+                            {
+                                break;
+                            }
                             var bars = data.Cast<QuoteBar>().ToList();
 
                             if (allResolutions)

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -222,6 +222,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private bool _historyDelistedAssetWarning;
         private bool _historyExpiredAssetWarning;
         private bool _historyOpenInterestWarning;
+        private bool _historyInvalidPeriodWarning;
 
         /// <summary>
         /// Returns true if we're currently connected to the broker
@@ -4074,6 +4075,17 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     _historyOpenInterestWarning = true;
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "GetHistoryOpenInterest", "IB does not provide open interest historical data"));
+                }
+                return null;
+            }
+
+            if (request.EndTimeUtc < request.StartTimeUtc)
+            {
+                if (!_historyInvalidPeriodWarning)
+                {
+                    _historyInvalidPeriodWarning = true;
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning,
+                        "GetHistoryEndTimeBeforeStartTime", "The history request end time is before the start time. No history will be returned."));
                 }
                 return null;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
