### PR TITLE
Adds Mapping to ETH Futures

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokers/IB-symbol-map.json
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokers/IB-symbol-map.json
@@ -16,6 +16,7 @@
   "RUR": "6R",
   "ZAR": "6Z",
   "BRR": "BTC",
+  "ETHUSDRR": "ETH",
   "DA": "DC",
   "BQX": "BIO"
 }

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -4119,7 +4119,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
         private static string GetContractMultiplier(decimal contractMultiplier)
         {
-            if (contractMultiplier >= 1)
+            if (contractMultiplier % 1 == 0)
             {
                 // IB doesn't like 5000.0
                 return Convert.ToInt32(contractMultiplier).ToStringInvariant();


### PR DESCRIPTION
#### Description
ETHUSDRR represents CME ETH: 
https://www.interactivebrokers.com/en/trading/margin-futures-fops.php

Fixes GetContractMultiplier
GetContractMultiplier was rounding the contract multiplier incorrectly, leading to an unsuccessful contract details request. E.g. LBR multiplier is 27.5 and was converted to "28" instead of "27.5".
Instead of rounding all multipliers above 1, we will only round them if the decimal part is zero.

![Tested locally](https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/assets/6889033/e91fd635-cdf8-4b33-badb-d823a7799413)


#### Motivation and Context
Missing mappings.
Bug fixing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`