### PR TITLE
Support Nikkei HSI indexes

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -2918,7 +2918,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             // Indexes requires that the exchange be specified exactly
             else if (symbol.ID.SecurityType == SecurityType.Index)
             {
-                contract.Exchange = IndexSymbol.GetIndexExchange(symbol);
+                if (string.Equals(symbol.ID.Market, Market.OSE, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    contract.Exchange = "OSE.JPN";
+                }
+                else
+                {
+                    contract.Exchange = IndexSymbol.GetIndexExchange(symbol);
+                }
             }
             else if (symbol.ID.SecurityType.IsOption())
             {
@@ -3787,7 +3794,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 (securityType == SecurityType.Forex && market == Market.Oanda) ||
                 (securityType == SecurityType.Option && market == Market.USA) ||
                 (securityType == SecurityType.IndexOption && market == Market.USA) ||
-                (securityType == SecurityType.Index && (market == Market.USA || market == Market.EUREX)) ||
+                (securityType == SecurityType.Index && (market == Market.USA || market == Market.EUREX || market == Market.OSE || market == Market.HKFE)) ||
                 (securityType == SecurityType.FutureOption) ||
                 (securityType == SecurityType.Future) ||
                 (securityType == SecurityType.Cfd && market == Market.InteractiveBrokers);


### PR DESCRIPTION
- Can subscribe should return true for `HKFE/OSE` markets on indexes
- OSE market needs a mapping for IB to "OSE.JPN"


```
Brokerage Info: Displaying delayed market data.. Origin: [Id=576] Subscribe: HSI27M25 (FUT HSI HKD hkfe  20250627 0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=577] Subscribe: HSI28H25 (FUT HSI HKD hkfe  20250328 0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=578] Subscribe: HSI27F25 (FUT HSI HKD hkfe  20250127 0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=579] Subscribe: HSI27G25 (FUT HSI HKD hkfe  20250227 0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=580] Subscribe: HSI29J25 (FUT HSI HKD hkfe  20250429 0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=581] Subscribe: HSI (IND HSI HKD hkfe   0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=583] Subscribe: RUT (IND RUT USD RUSSELL   0 )
Brokerage Info: Displaying delayed market data.. Origin: [Id=582] Subscribe: N225 (IND N225 JPY OSE.JPN   0 )
```