### PR TITLE
Tweak for FA order properties handling

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -2657,9 +2657,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 if (orderProperties != null)
                 {
                     if (!_sentFAOrderPropertiesWarning &&
-                        (!string.IsNullOrEmpty(orderProperties.FaProfile) && !string.IsNullOrEmpty(orderProperties.Account)
-                        || !string.IsNullOrEmpty(orderProperties.FaProfile) && !string.IsNullOrEmpty(orderProperties.FaGroup)
-                        || !string.IsNullOrEmpty(orderProperties.Account) && !string.IsNullOrEmpty(orderProperties.FaGroup)))
+                        (!string.IsNullOrWhiteSpace(orderProperties.FaProfile) && !string.IsNullOrWhiteSpace(orderProperties.Account)
+                        || !string.IsNullOrWhiteSpace(orderProperties.FaProfile) && !string.IsNullOrWhiteSpace(orderProperties.FaGroup)
+                        || !string.IsNullOrWhiteSpace(orderProperties.Account) && !string.IsNullOrWhiteSpace(orderProperties.FaGroup)))
                     {
                         // warning these are mutually exclusive
                         _sentFAOrderPropertiesWarning = true;


### PR DESCRIPTION
- Add warning if the user provides multiple exclusive options, FaProfile and FaGroup and Account are mutually exclusive
- When checking "Use Account Groups with Allocation Methods" (https://github.com/QuantConnect/IBAutomater/pull/92/files) `placeOrder will support specifying profile name as the IBApi.Order.FaGroup name; FaMethod may be omitted.`