### PR TITLE
Fix reconnection race condition

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -791,13 +791,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     // if message processing thread is still running, wait until it terminates
                     Disconnect();
 
-                    // At initial startup or after a gateway restart, we need to wait for the gateway to be ready for a connect request.
-                    // Attempting to connect to the socket too early will get a SocketException: Connection refused.
-                    if (_cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
-                    {
-                        break;
-                    }
-
+                    _waitForNextValidId.Reset();
                     _connectEvent.Reset();
 
                     // we're going to try and connect several times, if successful break

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -791,6 +791,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     // if message processing thread is still running, wait until it terminates
                     Disconnect();
 
+                    // At initial startup or after a gateway restart, we need to wait for the gateway to be ready for a connect request.
+                    // Attempting to connect to the socket too early will get a SocketException: Connection refused.
+                    if (_cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(2500)))
+                    {
+                        break;
+                    }
+
                     _waitForNextValidId.Reset();
                     _connectEvent.Reset();
 


### PR DESCRIPTION
- Add missing reset for waitForNextValidId, causing issues on reconnection
- Readding 2.5 seconds delay on reconnection

Reset event was added at but never reset https://github.com/QuantConnect/Lean/commit/c53468287232d4552f3bf8185803893f9a5d8b9b#diff-7e83826a2dfb11ca68eedfe5c6f5f72af1e98452706a0d2b9fabc7546d73a2af