### PR TITLE
Fix: skip index `NDX` the first lastTrade price each day

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -915,6 +915,48 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             brokerage.Message -= onMessage;
         }
 
+        [TestCase("2025-05-06T13:29:59", false, Description = "Before market open")]
+        [TestCase("2025-05-06T13:30:00", true, Description = "At market open")]
+        [TestCase("2025-05-06T13:30:15", true, Description = "Within first 30 seconds")]
+        [TestCase("2025-05-06T13:30:30", false, Description = "Exactly at 30 seconds")]
+        [TestCase("2025-05-06T13:31:00", false, Description = "After skip window")]
+        public void ShouldSkipTickMarketClosed(string utcTimeString, bool expectedResult)
+        {
+            var DateTimeUtcNow = DateTime.Parse(utcTimeString);
+
+            var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
+
+            var result = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, DateTimeUtcNow);
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [Test]
+        public void ShouldSkipTick_OnlyOnceWithinSkipWindow()
+        {
+            var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
+
+            // Tick on 2025-05-06 within the skip window — should skip
+            var firstUtc = DateTime.Parse("2025-05-06T13:30:15");
+            var firstResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, firstUtc);
+            Assert.IsTrue(firstResult, "Expected skip on first tick within window");
+
+            // Another tick same day — should not skip again
+            var secondUtc = DateTime.Parse("2025-05-06T13:30:17");
+            var secondResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, secondUtc);
+            Assert.IsFalse(secondResult, "Expected no skip after already skipped once today");
+
+            // Next day before market open — should not skip
+            var thirdUtc = DateTime.Parse("2025-05-07T13:29:28");
+            var thirdResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, thirdUtc);
+            Assert.IsFalse(thirdResult, "Expected no skip before market open next day");
+
+            // Next day within skip window — should skip again
+            var fourthUtc = DateTime.Parse("2025-05-07T13:30:02");
+            var fourthResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, fourthUtc);
+            Assert.IsTrue(fourthResult, "Expected skip on new day within skip window");
+        }
+
         private List<BaseData> GetHistory(
             Symbol symbol,
             Resolution resolution,

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -915,45 +915,45 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             brokerage.Message -= onMessage;
         }
 
-        [TestCase("2025-05-06T13:29:59", false, Description = "Before market open")]
-        [TestCase("2025-05-06T13:30:00", true, Description = "At market open")]
-        [TestCase("2025-05-06T13:30:15", true, Description = "Within first 30 seconds")]
-        [TestCase("2025-05-06T13:30:30", false, Description = "Exactly at 30 seconds")]
-        [TestCase("2025-05-06T13:31:00", false, Description = "After skip window")]
-        public void ShouldSkipTickMarketClosed(string utcTimeString, bool expectedResult)
+        [TestCase("2025-05-06T09:29:59", false, Description = "Before market open")]
+        [TestCase("2025-05-06T09:30:00", true, Description = "At market open")]
+        [TestCase("2025-05-06T09:30:15", true, Description = "Within first 30 seconds")]
+        [TestCase("2025-05-06T09:30:30", false, Description = "Exactly at 30 seconds")]
+        [TestCase("2025-05-06T09:31:00", false, Description = "After skip window")]
+        public void ShouldSkipTickMarketClosed(string localTimeString, bool expectedResult)
         {
-            var DateTimeUtcNow = DateTime.Parse(utcTimeString);
+            var DateTimeLocalNow = DateTime.Parse(localTimeString);
 
             var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
 
-            var result = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, DateTimeUtcNow);
+            var result = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, DateTimeLocalNow);
 
             Assert.AreEqual(expectedResult, result);
         }
 
         [Test]
-        public void ShouldSkipTick_OnlyOnceWithinSkipWindow()
+        public void ShouldSkipTickOnlyOnceWithinSkipWindow()
         {
             var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
 
-            // Tick on 2025-05-06 within the skip window — should skip
-            var firstUtc = DateTime.Parse("2025-05-06T13:30:15");
-            var firstResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, firstUtc);
+            // Tick on 2025-05-06 within the skip window - should skip
+            var firstLocalDateTime = DateTime.Parse("2025-05-06T09:30:15");
+            var firstResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, firstLocalDateTime);
             Assert.IsTrue(firstResult, "Expected skip on first tick within window");
 
-            // Another tick same day — should not skip again
-            var secondUtc = DateTime.Parse("2025-05-06T13:30:17");
-            var secondResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, secondUtc);
+            // Another tick same day - should not skip again
+            var secondLocalDateTime = DateTime.Parse("2025-05-06T09:30:17");
+            var secondResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, secondLocalDateTime);
             Assert.IsFalse(secondResult, "Expected no skip after already skipped once today");
 
-            // Next day before market open — should not skip
-            var thirdUtc = DateTime.Parse("2025-05-07T13:29:28");
-            var thirdResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, thirdUtc);
+            // Next day before market open - should not skip
+            var thirdLocalDateTime = DateTime.Parse("2025-05-07T09:29:28");
+            var thirdResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, thirdLocalDateTime);
             Assert.IsFalse(thirdResult, "Expected no skip before market open next day");
 
-            // Next day within skip window — should skip again
-            var fourthUtc = DateTime.Parse("2025-05-07T13:30:02");
-            var fourthResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, fourthUtc);
+            // Next day within skip window - should skip again
+            var fourthLocalDateTime = DateTime.Parse("2025-05-07T09:30:02");
+            var fourthResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, fourthLocalDateTime);
             Assert.IsTrue(fourthResult, "Expected skip on new day within skip window");
         }
 

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -926,7 +926,9 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
 
-            var result = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, DateTimeLocalNow);
+            var ndxSecurityExchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+
+            var result = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, DateTimeLocalNow);
 
             Assert.AreEqual(expectedResult, result);
         }
@@ -936,24 +938,26 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         {
             var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
 
+            var ndxSecurityExchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+
             // Tick on 2025-05-06 within the skip window - should skip
             var firstLocalDateTime = DateTime.Parse("2025-05-06T09:30:15");
-            var firstResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, firstLocalDateTime);
+            var firstResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, firstLocalDateTime);
             Assert.IsTrue(firstResult, "Expected skip on first tick within window");
 
             // Another tick same day - should not skip again
             var secondLocalDateTime = DateTime.Parse("2025-05-06T09:30:17");
-            var secondResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, secondLocalDateTime);
+            var secondResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, secondLocalDateTime);
             Assert.IsFalse(secondResult, "Expected no skip after already skipped once today");
 
             // Next day before market open - should not skip
             var thirdLocalDateTime = DateTime.Parse("2025-05-07T09:29:28");
-            var thirdResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, thirdLocalDateTime);
+            var thirdResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, thirdLocalDateTime);
             Assert.IsFalse(thirdResult, "Expected no skip before market open next day");
 
             // Next day within skip window - should skip again
             var fourthLocalDateTime = DateTime.Parse("2025-05-07T09:30:02");
-            var fourthResult = InteractiveBrokersBrokerage.ShouldSkipTick(symbol, fourthLocalDateTime);
+            var fourthResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, fourthLocalDateTime);
             Assert.IsTrue(fourthResult, "Expected skip on new day within skip window");
         }
 

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -988,6 +988,51 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.IsFalse(secondResult, "Expected skip after market open");
         }
 
+        [Test]
+        public void ShouldSkipTickOnlyOnceFromFridayToMonday()
+        {
+            InteractiveBrokersBrokerage._nextNdxMarketOpenSkipTime = default;
+
+            var symbol = Symbol.Create("NDX", SecurityType.Index, Market.USA);
+
+            var ndxSecurityExchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+
+            var fridayPreMarketDateTime = DateTime.Parse("2025-05-09T09:25:00");
+            var fridayPreMarketResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, fridayPreMarketDateTime);
+
+            Assert.IsFalse(fridayPreMarketResult);
+
+            var fridayMarketOpenDateTimeFirstTick = DateTime.Parse("2025-05-09T09:30:01");
+            var fridayMarketOpenFirstTickResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, fridayMarketOpenDateTimeFirstTick);
+
+            Assert.IsTrue(fridayMarketOpenFirstTickResult);
+
+            var fridayMarketOpenDateTimeSecondTick = DateTime.Parse("2025-05-09T09:30:01");
+            var fridayMarketOpenSecondTickResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, fridayMarketOpenDateTimeSecondTick);
+
+            Assert.IsFalse(fridayMarketOpenSecondTickResult);
+
+            var sundayDateTime = DateTime.Parse("2025-05-11T09:30:01");
+            var sundayResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, sundayDateTime);
+
+            Assert.IsFalse(sundayResult);
+
+            var mondayPreMarketDateTime = DateTime.Parse("2025-05-12T09:25:00");
+            var mondayPreMarketResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, mondayPreMarketDateTime);
+
+            Assert.IsFalse(mondayPreMarketResult);
+
+            var mondayMarketOpenDateTimeFirstTick = DateTime.Parse("2025-05-12T09:30:01");
+            var mondayMarketOpenFirstTickResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, mondayMarketOpenDateTimeFirstTick);
+
+            Assert.IsTrue(mondayMarketOpenFirstTickResult);
+
+            var mondayMarketOpenDateTimeSecondTick = DateTime.Parse("2025-05-12T09:30:01");
+            var mondayMarketOpenSecondTickResult = InteractiveBrokersBrokerage.ShouldSkipTick(ndxSecurityExchangeHours, mondayMarketOpenDateTimeFirstTick);
+
+            Assert.IsFalse(mondayMarketOpenSecondTickResult);
+        }
+
         private List<BaseData> GetHistory(
             Symbol symbol,
             Resolution resolution,

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -241,7 +241,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// Represents the next local market open time after which the first 'lastPrice' tick for the NDX index should be skipped.
         /// This is used to ensure only the initial tick after market open is ignored each trading day.
         /// </summary>
-        private static DateTime _nextNdxMarketOpenSkipTime = default;
+        internal static DateTime _nextNdxMarketOpenSkipTime = default;
 
         /// <summary>
         /// Stores the exchange hours for the NDX security, used to determine market open/close times and related calculations.
@@ -3922,11 +3922,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 case IBApi.TickType.LAST:
                 case IBApi.TickType.DELAYED_LAST:
-                    
+
                     if (symbol.SecurityType == SecurityType.Index && symbol.Value.Equals("NDX", StringComparison.InvariantCultureIgnoreCase))
                     {
                         _ndxSecurityExchangeHours ??= MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
-                        if (ShouldSkipTick(_ndxSecurityExchangeHours, DateTime.Now))
+                        if (ShouldSkipTick(_ndxSecurityExchangeHours, GetRealTimeTickTime(symbol)))
                         {
                             return;
                         }
@@ -5055,26 +5055,37 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private readonly ConcurrentDictionary<int, SubscriptionEntry> _subscribedTickers = new ConcurrentDictionary<int, SubscriptionEntry>();
 
         /// <summary>
-        /// Determines whether the current tick should be skipped for the NDX index
-        /// based on whether the current local time has reached or passed the next
-        /// scheduled market open. If the skip condition is met, the next skip time is updated.
+        /// Determines whether the current tick for the NDX index should be skipped,
+        /// based on whether the symbol's local time has reached or passed the next scheduled market open.
+        /// This is used to avoid processing unreliable ticks during the first 30 seconds of market open.
+        /// If the condition is met, the next skip time is updated to the following market open.
         /// </summary>
         /// <param name="exchangeHours">The exchange hours used to determine market open times.</param>
-        /// <param name="localDateTime">The current local time to evaluate.</param>
+        /// <param name="symbolTickTime">The local time of the tick to evaluate.</param>
         /// <returns>
-        /// True if the tick should be skipped (i.e., it's the first tick after market open);
-        /// otherwise, false.
+        /// <c>true</c> if the tick should be skipped (i.e., it's within the first 30 seconds after market open); otherwise, <c>false</c>.
         /// </returns>
-        internal static bool ShouldSkipTick(SecurityExchangeHours exchangeHours, DateTime localDateTime)
+        internal static bool ShouldSkipTick(SecurityExchangeHours exchangeHours, DateTime symbolTickTime)
         {
+            // Subtracting 30 seconds here is intentional:
+            // When the market opens (e.g., 9:30 AM EST), the first tick received for NDX via the IB API
+            // often contains the *previous day's close* as the price. This stale tick appears at or just after open.
+            //
+            // The *second* tick that arrives - still within the first few seconds - contains the correct
+            // open price and is the one displayed in IB TWS's open bar.
+            //
+            // By subtracting 30 seconds, we ensure we look *just before* the current tick time,
+            // so `GetNextMarketOpen()` gives us today's 9:30 AM open (not tomorrow's).
+            // This allows us to create a small "skip window" right after market open,
+            // avoiding use of inaccurate initial pricing.
             if (_nextNdxMarketOpenSkipTime == default)
             {
-                _nextNdxMarketOpenSkipTime = exchangeHours.GetNextMarketOpen(localDateTime, false);
+                _nextNdxMarketOpenSkipTime = exchangeHours.GetNextMarketOpen(symbolTickTime.AddSeconds(-30), false);
             }
 
-            if (localDateTime >= _nextNdxMarketOpenSkipTime)
+            if (symbolTickTime >= _nextNdxMarketOpenSkipTime)
             {
-                _nextNdxMarketOpenSkipTime = exchangeHours.GetNextMarketOpen(localDateTime, false);
+                _nextNdxMarketOpenSkipTime = exchangeHours.GetNextMarketOpen(symbolTickTime, false);
                 return true;
             }
 


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->

While users use **NDX index data from Interactive Brokers (IB)**, they observed a critical issue occurring at **market open (9:30 AM EST)**. The first `LastPrice` tick received right after the open contains the **previous day's closing price**, not the actual opening price.

At exactly `9:30:15.258` on `2025-05-06`, two `LastPrice` ticks were received for NDX:
```
First Tick LastPrice: 19967.94  ← stale previous close
Second Tick LastPrice: 19709.64 ← correct opening price
```

IB TWS chart confirmed the **actual opening price** was `19709.64`, not `19967.94`. However, Lean processed the first stale tick into the opening bar:
```
Incorrect Lean Candle:
O: 19967.94 H: 19967.94 L: 19699.70 C: 19705.72
```
This resulted in a mispriced opening candle with an invalid open value, breaking strategy accuracy for the first minute.

![image](https://github.com/user-attachments/assets/5895d584-8858-48b6-8c20-23f19a2d9f47)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/a

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents Lean from using stale `LastPrice` ticks that represent the **previous day's close**.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Validate `ShouldSkipTick()` with various TestCases.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
