### PR TITLE
Feat: cache contract specification and service

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1112,17 +1112,20 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             foreach (var symbol in symbols)
             {
                 var contract = CreateContract(symbol);
-                var tradingClass = ib.GetTradingClass(contract, symbol);
+                var tradingClass = ib._contractSpecificationService.GetTradingClass(contract, symbol);
 
                 Assert.IsFalse(string.IsNullOrEmpty(tradingClass), $"Trading class should not be null or empty for symbol {symbol}");
 
                 if (symbol.HasCanonical())
                 {
-                    Assert.IsTrue(ib._tradingClassByCanonicalSymbol.ContainsKey(symbol.Canonical), $"Cache should contain canonical for symbol {symbol}");
+                    Assert.IsTrue(ib._contractSpecificationService._tradingClassByCanonicalSymbol.TryGetValue(symbol.Canonical, out var contractSpecification),
+                        $"Cache should contain canonical for symbol {symbol}");
+                    Assert.IsNotEmpty(contractSpecification.TradingClass);
+                    Assert.Greater(contractSpecification.MinTick, 0m);
                 }
                 else
                 {
-                    Assert.IsFalse(ib._tradingClassByCanonicalSymbol.ContainsKey(symbol.Canonical));
+                    Assert.IsFalse(ib._contractSpecificationService._tradingClassByCanonicalSymbol.ContainsKey(symbol.Canonical));
                 }
             }
             stopwatch.Stop();

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecification.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecification.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Brokerages.InteractiveBrokers.Client
+{
+    /// <summary>
+    /// Describes a tradable instrument's trading class and minimum tick size,
+    /// as provided by an Interactive Brokers <c>reqContractDetails(...)</c> request.
+    /// </summary>
+    public class ContractSpecification
+    {
+        /// <summary>
+        /// Gets the IB trading class of the instrument.
+        /// For example, for Apple stock options this value may be <c>AAPL</c>.
+        /// </summary>
+        public string TradingClass { get; }
+
+        /// <summary>
+        /// Gets the minimum price increment (tick size) for the instrument.
+        /// For example, <c>0.01</c> means prices move in 1-cent increments.
+        /// </summary>
+        public decimal MinTick { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContractSpecification"/> class.
+        /// </summary>
+        /// <param name="tradingClass">
+        /// The IB trading class of the instrument, identifying its group or symbol root.
+        /// </param>
+        /// <param name="minTick">
+        /// The smallest allowed price increment for this instrument.
+        /// </param>
+        public ContractSpecification(string tradingClass, decimal minTick)
+        {
+            TradingClass = tradingClass;
+            MinTick = minTick;
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
                 contract.TradingClass = symbol.ID.Symbol;
             }
 
-            var details = _getContractDetails(contract, symbol.Value, false);
+            var details = _getContractDetails(contract, symbol.Value, true);
             if (details == null)
             {
                 return null; // Unable to find contract details

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using IBApi;
+using System;
+using System.Collections.Concurrent;
+
+namespace QuantConnect.Brokerages.InteractiveBrokers.Client
+{
+    /// <summary>
+    /// Provides a cached lookup for an instrument's trading class and minimum tick size using Interactive Brokers <c>ContractDetails</c> data.
+    /// </summary>
+    /// <remarks>
+    /// This service reduces the number of IB <c>reqContractDetails</c> requests by caching
+    /// the <see cref="ContractSpecification"/> for all instruments in the same option chain.
+    /// </remarks>
+    public class ContractSpecificationService
+    {
+        /// <summary>
+        /// Delegate used to request Interactive Brokers contract details.
+        /// </summary>
+        private Func<Contract, string, bool, ContractDetails> _getContractDetails;
+
+        /// <summary>
+        /// Thread-safe cache that maps canonical <see cref="Symbol"/> instances to their associated trading class.
+        /// </summary>
+        /// <remarks>
+        /// This collection is used to reduce the number of <see cref="_client.ClientSocket.reqContractDetails(requestId, contract);"/> requests
+        /// for option chains, since all options in the same chain share the same trading class.
+        /// </remarks>
+        private readonly ConcurrentDictionary<Symbol, ContractSpecification> _tradingClassByCanonicalSymbol = [];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContractSpecificationService"/> class.
+        /// </summary>
+        /// <param name="getContractDetails">
+        /// Delegate function used to retrieve IB <see cref="ContractDetails"/> for a given contract.
+        /// </param>
+        public ContractSpecificationService(Func<Contract, string, bool, ContractDetails> getContractDetails)
+        {
+            _getContractDetails = getContractDetails;
+        }
+
+        /// <summary>
+        /// Gets the trading class for the specified contract and symbol, using cached data if available.
+        /// </summary>
+        /// <param name="contract">The IB contract to retrieve data for.</param>
+        /// <param name="symbol">The associated Lean symbol.</param>
+        /// <returns>The trading class string, or <c>null</c> if the data could not be retrieved.</returns>
+        public string GetTradingClass(Contract contract, Symbol symbol) => GetOrAddSpecification(contract, symbol)?.TradingClass;
+
+        /// <summary>
+        /// Gets the minimum price increment (tick size) for the specified contract and symbol,
+        /// using cached data if available.
+        /// </summary>
+        /// <param name="contract">The IB contract to retrieve data for.</param>
+        /// <param name="symbol">The associated Lean symbol.</param>
+        /// <returns>
+        /// The minimum tick size, or <c>0</c> if the data could not be retrieved.
+        /// </returns>
+        public decimal GetMinTick(Contract contract, Symbol symbol) => GetOrAddSpecification(contract, symbol)?.MinTick ?? 0m;
+
+        /// <summary>
+        /// Gets the <see cref="ContractSpecification"/> for the given contract and symbol,
+        /// retrieving it from the cache if present or requesting it from IB if not.
+        /// </summary>
+        /// <param name="contract">The IB contract to retrieve data for.</param>
+        /// <param name="symbol">The associated Lean symbol.</param>
+        /// <returns>
+        /// The <see cref="ContractSpecification"/> containing the trading class and minimum tick size,
+        /// or <c>null</c> if the data could not be retrieved.
+        /// </returns>
+        private ContractSpecification GetOrAddSpecification(Contract contract, Symbol symbol)
+        {
+            var canonicalSymbol = symbol.HasCanonical() ? symbol.Canonical : null;
+            if (canonicalSymbol is not null && _tradingClassByCanonicalSymbol.TryGetValue(canonicalSymbol, out var cached))
+            {
+                return cached;
+            }
+
+            if (symbol.SecurityType is QuantConnect.SecurityType.FutureOption or QuantConnect.SecurityType.IndexOption)
+            {
+                // Futures options and Index Options trading class is the same as the FOP ticker.
+                // This is required in order to resolve the contract details successfully.
+                // We let this method complete even though we assign twice so that the
+                // contract details are added to the cache and won't require another lookup.
+                contract.TradingClass = symbol.ID.Symbol;
+            }
+
+            var details = _getContractDetails(contract, symbol.Value, false);
+            if (details == null)
+            {
+                return null; // Unable to find contract details
+            }
+
+            var specification = new ContractSpecification(details.Contract.TradingClass, Convert.ToDecimal(details.MinTick));
+            if (canonicalSymbol is not null)
+            {
+                _tradingClassByCanonicalSymbol[canonicalSymbol] = specification;
+            }
+
+            return specification;
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
@@ -58,8 +58,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// </summary>
         /// <param name="contract">The IB contract to retrieve data for.</param>
         /// <param name="symbol">The associated Lean symbol.</param>
+        /// <param name="failIfNotFound">
+        /// If <c>true</c>, the request is treated as a required lookup and will be logged as a <see cref="InteractiveBrokersBrokerage.RequestType.ContractDetails"/> request.
+        /// If <c>false</c>, the request is treated as a soft lookup (<see cref="InteractiveBrokersBrokerage.RequestType.SoftContractDetails"/>) that does not cause a failure if no details are found.
+        /// </param>
         /// <returns>The trading class string, or <c>null</c> if the data could not be retrieved.</returns>
-        public string GetTradingClass(Contract contract, Symbol symbol) => GetOrAddSpecification(contract, symbol)?.TradingClass;
+        public string GetTradingClass(Contract contract, Symbol symbol, bool failIfNotFound = true) => GetOrAddSpecification(contract, symbol, failIfNotFound)?.TradingClass;
 
         /// <summary>
         /// Gets the minimum price increment (tick size) for the specified contract and symbol,
@@ -67,10 +71,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// </summary>
         /// <param name="contract">The IB contract to retrieve data for.</param>
         /// <param name="symbol">The associated Lean symbol.</param>
+        /// <param name="failIfNotFound">
+        /// If <c>true</c>, the request is treated as a required lookup and will be logged as a <see cref="InteractiveBrokersBrokerage.RequestType.ContractDetails"/> request.
+        /// If <c>false</c>, the request is treated as a soft lookup (<see cref="InteractiveBrokersBrokerage.RequestType.SoftContractDetails"/>) that does not cause a failure if no details are found.
+        /// </param>
         /// <returns>
         /// The minimum tick size, or <c>0</c> if the data could not be retrieved.
         /// </returns>
-        public decimal GetMinTick(Contract contract, Symbol symbol) => GetOrAddSpecification(contract, symbol)?.MinTick ?? 0m;
+        public decimal GetMinTick(Contract contract, Symbol symbol, bool failIfNotFound = true) => GetOrAddSpecification(contract, symbol, failIfNotFound)?.MinTick ?? 0m;
 
         /// <summary>
         /// Gets the <see cref="ContractSpecification"/> for the given contract and symbol,
@@ -78,11 +86,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// </summary>
         /// <param name="contract">The IB contract to retrieve data for.</param>
         /// <param name="symbol">The associated Lean symbol.</param>
+        /// <param name="failIfNotFound">
+        /// If <c>true</c>, the request is treated as a required lookup and will be logged as a <see cref="InteractiveBrokersBrokerage.RequestType.ContractDetails"/> request.
+        /// If <c>false</c>, the request is treated as a soft lookup (<see cref="InteractiveBrokersBrokerage.RequestType.SoftContractDetails"/>) that does not cause a failure if no details are found.
+        /// </param>
         /// <returns>
         /// The <see cref="ContractSpecification"/> containing the trading class and minimum tick size,
         /// or <c>null</c> if the data could not be retrieved.
         /// </returns>
-        private ContractSpecification GetOrAddSpecification(Contract contract, Symbol symbol)
+        private ContractSpecification GetOrAddSpecification(Contract contract, Symbol symbol, bool failIfNotFound)
         {
             var canonicalSymbol = symbol.HasCanonical() ? symbol.Canonical : null;
             if (canonicalSymbol is not null && _tradingClassByCanonicalSymbol.TryGetValue(canonicalSymbol, out var cached))
@@ -99,7 +111,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
                 contract.TradingClass = symbol.ID.Symbol;
             }
 
-            var details = _getContractDetails(contract, symbol.Value, true);
+            var details = _getContractDetails(contract, symbol.Value, failIfNotFound);
             if (details == null)
             {
                 return null; // Unable to find contract details

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/ContractSpecificationService.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// This collection is used to reduce the number of <see cref="_client.ClientSocket.reqContractDetails(requestId, contract);"/> requests
         /// for option chains, since all options in the same chain share the same trading class.
         /// </remarks>
-        private readonly ConcurrentDictionary<Symbol, ContractSpecification> _tradingClassByCanonicalSymbol = [];
+        internal readonly ConcurrentDictionary<Symbol, ContractSpecification> _tradingClassByCanonicalSymbol = [];
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContractSpecificationService"/> class.

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -226,7 +226,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// Provides cached access to Interactive Brokers contract specifications,
         /// including trading class and minimum tick size, to reduce duplicate <c>reqContractDetails</c> requests.
         /// </summary>
-        private IB.ContractSpecificationService _contractSpecificationService;
+        internal IB.ContractSpecificationService _contractSpecificationService;
 
         // when unsubscribing symbols immediately after subscribing IB returns an error (Can't find EId with tickerId:nnn),
         // so we track subscription times to ensure symbols are not unsubscribed before a minimum time span has elapsed

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -223,13 +223,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private readonly ConcurrentDictionary<int, RequestInformation> _requestInformation = new();
 
         /// <summary>
-        /// Thread-safe cache that maps canonical <see cref="Symbol"/> instances to their associated trading class.
+        /// Provides cached access to Interactive Brokers contract specifications,
+        /// including trading class and minimum tick size, to reduce duplicate <c>reqContractDetails</c> requests.
         /// </summary>
-        /// <remarks>
-        /// This collection is used to reduce the number of <see cref="_client.ClientSocket.reqContractDetails(requestId, contract);"/> requests
-        /// for option chains, since all options in the same chain share the same trading class.
-        /// </remarks>
-        internal readonly ConcurrentDictionary<Symbol, string> _tradingClassByCanonicalSymbol = [];
+        private IB.ContractSpecificationService _contractSpecificationService;
 
         // when unsubscribing symbols immediately after subscribing IB returns an error (Can't find EId with tickerId:nnn),
         // so we track subscription times to ensure symbols are not unsubscribed before a minimum time span has elapsed
@@ -1376,6 +1373,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             _agentDescription = agentDescription;
 
             _symbolMapper = new InteractiveBrokersSymbolMapper(_mapFileProvider);
+            _contractSpecificationService = new(GetContractDetails);
 
             _subscriptionManager = new EventBasedDataQueueHandlerSubscriptionManager();
             _subscriptionManager.SubscribeImpl += (s, t) => Subscribe(s);
@@ -1629,55 +1627,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             return details.Contract.PrimaryExch;
         }
 
-        internal string GetTradingClass(Contract contract, Symbol symbol)
-        {
-            var canonicalSymbol = symbol.HasCanonical() ? symbol.Canonical : null;
-            if (canonicalSymbol is not null && _tradingClassByCanonicalSymbol.TryGetValue(canonicalSymbol, out var tradingClass))
-            {
-                return tradingClass;
-            }
-
-            if (_contractDetails.TryGetValue(GetUniqueKey(contract), out var details))
-            {
-                return details.Contract.TradingClass;
-            }
-
-            if (symbol.SecurityType == SecurityType.FutureOption || symbol.SecurityType == SecurityType.IndexOption)
-            {
-                // Futures options and Index Options trading class is the same as the FOP ticker.
-                // This is required in order to resolve the contract details successfully.
-                // We let this method complete even though we assign twice so that the
-                // contract details are added to the cache and won't require another lookup.
-                contract.TradingClass = symbol.ID.Symbol;
-            }
-
-            details = GetContractDetailsImpl(contract, symbol.Value);
-            if (details == null)
-            {
-                // we were unable to find the contract details
-                return null;
-            }
-
-            if (canonicalSymbol is not null)
-            {
-                _tradingClassByCanonicalSymbol[canonicalSymbol] = details.Contract.TradingClass;
-            }
-
-            return details.Contract.TradingClass;
-        }
-
-        private decimal GetMinTick(Contract contract, string ticker)
-        {
-            var details = GetContractDetails(contract, ticker);
-            if (details == null)
-            {
-                // we were unable to find the contract details
-                return 0;
-            }
-
-            return (decimal)details.MinTick;
-        }
-
         /// <summary>
         /// Will return and cache the IB contract details for the requested contract
         /// </summary>
@@ -1804,12 +1753,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <param name="price">Price to be normalized</param>
         /// <param name="contract">Contract of the symbol</param>
         /// <param name="symbol">The symbol from which we need to get the PriceMagnifier attribute to normalize the price</param>
-        /// <param name="minTick">The minimum allowed price variation</param>
         /// <returns>The price normalized to be brokerage expected unit</returns>
-        public double NormalizePriceToBrokerage(decimal price, Contract contract, Symbol symbol, decimal? minTick = null)
+        public double NormalizePriceToBrokerage(decimal price, Contract contract, Symbol symbol)
         {
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, Currencies.USD);
-            var roundedPrice = RoundPrice(price, minTick ?? GetMinTick(contract, symbol.Value));
+            var roundedPrice = RoundPrice(price, _contractSpecificationService.GetMinTick(contract, symbol));
             roundedPrice *= symbolProperties.PriceMagnifier;
             return Convert.ToDouble(roundedPrice);
         }
@@ -2894,15 +2842,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
             else if (stopLimitOrder != null)
             {
-                var minTick = GetMinTick(contract, order.Symbol.Value);
-                ibOrder.LmtPrice = NormalizePriceToBrokerage(stopLimitOrder.LimitPrice, contract, order.Symbol, minTick);
-                ibOrder.AuxPrice = NormalizePriceToBrokerage(stopLimitOrder.StopPrice, contract, order.Symbol, minTick);
+                ibOrder.LmtPrice = NormalizePriceToBrokerage(stopLimitOrder.LimitPrice, contract, order.Symbol);
+                ibOrder.AuxPrice = NormalizePriceToBrokerage(stopLimitOrder.StopPrice, contract, order.Symbol);
             }
             else if (limitIfTouchedOrder != null)
             {
-                var minTick = GetMinTick(contract, order.Symbol.Value);
-                ibOrder.LmtPrice = NormalizePriceToBrokerage(limitIfTouchedOrder.LimitPrice, contract, order.Symbol, minTick);
-                ibOrder.AuxPrice = NormalizePriceToBrokerage(limitIfTouchedOrder.TriggerPrice, contract, order.Symbol, minTick);
+                ibOrder.LmtPrice = NormalizePriceToBrokerage(limitIfTouchedOrder.LimitPrice, contract, order.Symbol);
+                ibOrder.AuxPrice = NormalizePriceToBrokerage(limitIfTouchedOrder.TriggerPrice, contract, order.Symbol);
             }
             else if (comboLimitOrder != null)
             {
@@ -3295,7 +3241,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     .ContractMultiplier
                     .ToStringInvariant();
 
-                contract.TradingClass = GetTradingClass(contract, symbol);
+                contract.TradingClass = _contractSpecificationService.GetTradingClass(contract, symbol);
                 contract.IncludeExpired = includeExpired;
             }
             else if (symbol.ID.SecurityType == SecurityType.Future)

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1646,6 +1646,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </summary>
         /// <param name="contract">The target contract</param>
         /// <param name="ticker">The associated Lean ticker. Just used for logging, can be provided empty</param>
+        /// <param name="failIfNotFound">
+        /// If <c>true</c>, the request is treated as a required lookup and will be logged as a <see cref="RequestType.ContractDetails"/> request.
+        /// If <c>false</c>, the request is treated as a soft lookup (<see cref="RequestType.SoftContractDetails"/>) that does not cause a failure if no details are found.
+        /// </param>
         private ContractDetails GetContractDetailsImpl(Contract contract, string ticker, bool failIfNotFound = true)
         {
             const int timeout = 60; // sec


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

### Related PRs
- Changing of `GetMinTick()`. - https://github.com/QuantConnect/Lean/pull/5930
- Optimize `GetContractDetails()`. - https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/180
- Use `true` in the delegate `getContractDetails()` within `class ContractSpecificationService` for Option, IndexOption, FutureOption. https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/100

### Related Issue
- Increase speed of getting history FutureOptions https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/issues/98
- Partly, we have taken the #48, when you tried to trade option contracts. Now, `TradingClass` and `MinTick` will fetch from cache for the next request.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Requires Documentation Change
N/a

### How Has This Been Tested?
#### Test `GetMinTick()` with various SecurityTypes:
I have tested `GetMinTick()` with various Security Types to properly understand how we can cache and reuse it in our app:
- Option AAPL chain (2000+ symbols): `0.01` minTick
- Future ES19U25 (2000+ symbols):
  - Future: `0.25` (1400 symbols) minTick
  - FutureOption: `0.05` (700 symbols) or
- IndexOption SPX, SPXW, VIX, VIXW (2700+ symbols):
  - VIX (402): `0.01` minTick
  - VIXW (1152): `0.01` minTick
  - SPX (480): `0.05` minTick
  - SPXW (720): `0.05` minTick

#### The Lean Algrotihm -> `AddFutureContract(...)`
Test Algo:
```
var futureContract = AddFutureContract(QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2025, 09, 19)), Resolution.Minute).Symbol;

Logging.Log.Trace($"We have tried to subscribe on {OptionChain(futureContract).Count} future option contracts.");

foreach (var fo in OptionChain(futureContract))
{
  AddFutureOptionContract(fo);
}

SetWarmUp(5, Resolution.Daily);
```
Result:
- The option chain returned 236 future option contracts, demonstrating comprehensive retrieval of available contracts.
- The system issues two reqContractDetails() requests:
  - One for the canonical future contract itself
    - (`GetContractDetails: ES19U25 (FUT ES USD CME), TradingClass = ES, MinTick = 0.25`)
  - One for a representative future option contract.
    - `GetContractDetails: ES19U25  250919C05100000 (FOP ES USD CME), TradingClass = ES, MinTick = 0.05`
- The test confirms that the option contract details are correctly retrieved and cached based on the canonical future option symbol.
- The process of subscribing to all future option contracts and performing the `SetWarmUp` takes **approximately 2 minutes and 4.8 seconds**, indicating the time required for full subscription and warm-up in this scenario.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
