### PR TITLE
Fix: Inform user about "no market data during competing live session"

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1677,6 +1677,8 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             Assert.IsTrue(brokerage.IsConnected);
 
+            brokerage.Message += OnMessage;
+
             for (var i = 0; i < invocationCount; i++)
             {
                 var errorEvent = new IB.ErrorEventArgs(

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1708,7 +1708,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             }
 
             Assert.AreEqual(1, emittedCount, "Handler should throttle repeated messages within interval");
-            handler.Handle(now.AddSeconds(6), IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode, "Test message 2");
+            handler.Handle(now.AddMinutes(15).AddSeconds(1), IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode, "Test message 2");
             Assert.AreEqual(2, emittedCount, "Handler should emit again after throttle interval");
         }
     }

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1659,5 +1659,38 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             }
             throw new NotImplementedException();
         }
+
+        [Test]
+        public void HandleErrorCompetingLiveSessionIsThrottled()
+        {
+            using var brokerage = GetBrokerage();
+            const int invocationCount = 5;
+            var messageInvocationCount = 0;
+
+            void OnMessage(object _, BrokerageMessageEvent message)
+            {
+                if (message.Code == IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode.ToString())
+                {
+                    messageInvocationCount++;
+                }
+            }
+
+            Assert.IsTrue(brokerage.IsConnected);
+
+            for (var i = 0; i < invocationCount; i++)
+            {
+                var errorEvent = new IB.ErrorEventArgs(
+                    id: 1,
+                    time: 0,
+                    code: IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode,
+                    message: "No market data during competing live session. Origin: [Id=5] Subscribe: SPY (STK SPY USD Smart ARCA  0 )");
+
+                brokerage.HandleError(this, errorEvent);
+            }
+
+            brokerage.Message -= OnMessage;
+
+            Assert.That(messageInvocationCount, Is.EqualTo(1));
+        }
     }
 }

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/CompetingLiveSessionMarketDataErrorHandler.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/CompetingLiveSessionMarketDataErrorHandler.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <summary>
         /// Minimum time between emitted messages.
         /// </summary>
-        private static readonly TimeSpan ThrottleInterval = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan ThrottleInterval = TimeSpan.FromMinutes(15);
 
         /// <summary>
         /// Next UTC time when execution is allowed.

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/CompetingLiveSessionMarketDataErrorHandler.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/CompetingLiveSessionMarketDataErrorHandler.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2026 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Brokerages.InteractiveBrokers.Client
+{
+    /// <summary>
+    /// Handles competing live session market data errors with throttled notifications.
+    /// </summary>
+    public class CompetingLiveSessionMarketDataErrorHandler
+    {
+        /// <summary>
+        /// IB error code indicating that market data is unavailable due to a competing live session.
+        /// </summary>
+        /// <remarks>
+        /// Example IB event error:
+        /// RequestId: 5 ErrorCode: 10197 - No market data during competing live session. Origin: [Id=5] Subscribe: SPY (STK SPY USD Smart ARCA  0 )
+        /// </remarks>
+        public const int ErrorCode = 10197;
+
+        /// <summary>
+        /// Minimum time between emitted messages.
+        /// </summary>
+        private static readonly TimeSpan ThrottleInterval = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Next UTC time when execution is allowed.
+        /// </summary>
+        private DateTime _nextAllowedExecutionUtc;
+
+        /// <summary>
+        /// Message publishing callback.
+        /// </summary>
+        private readonly Action<BrokerageMessageEvent> _onMessage;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompetingLiveSessionMarketDataErrorHandler"/> class.
+        /// </summary>
+        /// <param name="onMessage">
+        /// Callback invoked when an error message needs to be published.
+        /// </param>
+        public CompetingLiveSessionMarketDataErrorHandler(Action<BrokerageMessageEvent> onMessage)
+        {
+            _onMessage = onMessage;
+        }
+
+        /// <summary>
+        /// Handles an error if throttling allows.
+        /// </summary>
+        public void Handle(DateTime utcNow, int code, string message)
+        {
+            if (utcNow < _nextAllowedExecutionUtc)
+            {
+                return;
+            }
+
+            _nextAllowedExecutionUtc = utcNow.Add(ThrottleInterval);
+            _onMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, code, message));
+        }
+    }
+}


### PR DESCRIPTION
#### Description
Display a warning to the user explaining why they are not receiving data updates.
```
Brokerage.OnMessage(): Warning - Code: 10197 - No market data during competing live session. Origin: [Id=5] Subscribe: SPY (STK SPY USD Smart ARCA  0 )
```

#### Related Issue
close #140 

#### Motivation and Context
Make interactions with Brokerage IB more warm and user-friendly.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<img width="352" height="118" alt="image" src="https://github.com/user-attachments/assets/c696266d-d4ea-4ce0-926c-79031274f871" />


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
