### PR TITLE
Fix: normalization price for IndexOption orders

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersCfdOrderTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersCfdOrderTests.cs
@@ -13,11 +13,13 @@
  * limitations under the License.
 */
 
+using System;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Brokerages.InteractiveBrokers;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 {
@@ -278,6 +280,18 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         #endregion
 
         // TODO: Add tests to get holdings after placing orders
+
+        [Test]
+        public void ComboLimitOrderIndex()
+        {
+            var spx = Symbol.Create("SPX", SecurityType.Index, Market.USA);
+            var spxCanonical = Symbol.CreateCanonicalOption(spx, targetOption: "SPXW");
+            var parameters = new ComboLimitOrderTestParameters(
+                OptionStrategies.BullPutSpread(spxCanonical, 7510m, 7500m, new DateTime(2026, 02, 20)),
+                askPrice: 0.75m,
+                bidPrice: -0.12m);
+            base.CancelComboOrders(parameters);
+        }
 
         protected override bool IsAsync()
         {

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1899,7 +1899,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             if (!_hasLoggedPriceRoundingWarning && !price.Equals(roundedPrice))
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "PriceRounding",
-                    $"To meet brokerage precision requirements, price was rounded to {roundedPrice.ToStringInvariant()} from {price.ToStringInvariant()}")
+                    $"To meet brokerage precision requirements, price was rounded to {roundedPrice.ToStringInvariant()} from {price.ToStringInvariant()} due to minimum tick size constraint ({minTick}).")
                 );
                 _hasLoggedPriceRoundingWarning = true;
             }

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1877,15 +1877,16 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <param name="price">Price to be normalized</param>
         /// <param name="contract">Contract of the symbol</param>
         /// <param name="symbol">The symbol from which we need to get the PriceMagnifier attribute to normalize the price</param>
+        /// <param name="orderType">The order type, used for special cases like Index Options ComboLimit orders</param>
         /// <returns>The price normalized to be brokerage expected unit</returns>
-        public double NormalizePriceToBrokerage(decimal price, Contract contract, Symbol symbol)
+        public double NormalizePriceToBrokerage(decimal price, Contract contract, Symbol symbol, OrderType? orderType = null)
         {
             var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, Currencies.USD);
 
             var minTick = 0m;
             switch (symbol.SecurityType)
             {
-                case SecurityType.IndexOption:
+                case SecurityType.IndexOption when orderType != OrderType.ComboLimit:
                     minTick = IndexOptionSymbolProperties.MinimumPriceVariationForPrice(symbol, price);
                     break;
                 default:
@@ -2997,7 +2998,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 AddGuaranteedTag(ibOrder, orders.All(x => x.SecurityType == SecurityType.Equity));
                 var baseContract = CreateContract(order.Symbol, includeExpired: false);
-                ibOrder.LmtPrice = NormalizePriceToBrokerage(comboLimitOrder.GroupOrderManager.LimitPrice, baseContract, order.Symbol);
+                ibOrder.LmtPrice = NormalizePriceToBrokerage(comboLimitOrder.GroupOrderManager.LimitPrice, baseContract, order.Symbol, OrderType.ComboLimit);
             }
             else if (comboMarketOrder != null)
             {


### PR DESCRIPTION
#### Description
#### 
The obtaining `MinTick` for `IndexOption` from IB API always receives `0.05` (it's wrong).
The [`IndexOptionSymbolProperties.MinimumPriceVariationForPrice`](https://github.com/QuantConnect/Lean/blob/master/Common/Securities/IndexOption/IndexOptionSymbolProperties.cs#L78) gives the correct minimum tick size constraint.

<img width="801" height="465" alt="image" src="https://github.com/user-attachments/assets/9da60680-cc9c-4fea-8215-84a56b992a26" />

---

Additionally, we have discovered that the minimum tick size constraint is always the same for `ComboLimit` and `ComboLegLimit` Orders and is equal to `0.05`.

<img width="942" height="655" alt="image (1)" src="https://github.com/user-attachments/assets/71845612-3065-4768-a16a-9552d7e66e9f" />

---

Example of a new warning message to users:

<img width="1789" height="202" alt="image" src="https://github.com/user-attachments/assets/cdb72ce2-3225-43e4-99c0-9d381a3c3c36" />

---

Validation of MinTick with ticker support in Lean.
| ticker | greater (>) 3$ | less (<) 3$ | link                                                                                               |
| ------ | -------------- | ----------- | -------------------------------------------------------------------------------------------------  |
| ndx    | 0.1            | 0.05        | https://www.nasdaq.com/NDX_NDXP_Factsheet                                                          |
| ndxp   | 0.1            | 0.05        | https://www.nasdaq.com/NDX_NDXP_Factsheet                                                          |
| nqx    | 0.1            | 0.05        | https://www.nasdaq.com/NQXindexoptions                                                             |
| rut    | 0.1            | 0.05        | https://www.cboe.com/tradable_products/ftse_russell/russell_2000_index_options/rut_specifications/ |
| rutw   | 0.1            | 0.05        | https://www.cboe.com/tradable_products/ftse_russell/russell_2000_index_options/rut_specifications/ |
| spx    | 0.1            | 0.05        | https://www.cboe.com/tradable-products/sp-500/spx-options/spx-specifications                       |
| spxw   | 0.1            | 0.05        | https://www.cboe.com/tradable-products/sp-500/spx-options/spx-specifications                       |
| vix    | 0.05           | 0.01        | https://www.cboe.com/tradable-products/vix/vix-options/specifications                              |
| vixw   | 0.01           | 0.01        | https://www.cboe.com/tradable-products/vix/vix-options/specifications                              |


#### Related Issue
closes #103 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
- Added Test Case which reproduces the attached issue.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
