### PR TITLE
Fix: populate ConId from cached contract details for equity symbols

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -3345,7 +3345,19 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
             else if (symbol.ID.SecurityType == SecurityType.Equity)
             {
-                contract.PrimaryExch = GetPrimaryExchange(contract, symbol);
+                // Look up cached contract details to get PrimaryExch AND ConId.
+                // ConId is critical for symbols that IB cannot resolve by ticker alone
+                // (e.g. dual-listed ETFs like EQQU on LSEETF where SMART routing fails
+                // without an explicit ConId).
+                var equityDetails = GetContractDetails(contract, symbol.Value, failIfNotFound: false);
+                if (equityDetails != null)
+                {
+                    contract.PrimaryExch = equityDetails.Contract.PrimaryExch;
+                    if (equityDetails.Contract.ConId > 0)
+                    {
+                        contract.ConId = equityDetails.Contract.ConId;
+                    }
+                }
             }
             // Indexes requires that the exchange be specified exactly
             else if (symbol.ID.SecurityType == SecurityType.Index)


### PR DESCRIPTION
## Problem

`CreateContract()` for equity symbols only sets `PrimaryExch` via `GetPrimaryExchange()`. The `ConId` field is left at 0.

For most US equities this works fine because IB can resolve the ticker through SMART routing. But for dual-listed or ambiguous tickers (e.g. EQQU on LSEETF, or EXUS which exists on both NASDAQ and LSEETF), IB cannot resolve the symbol by name alone and the request fails silently or returns the wrong contract.

This affects subscribe, history, and order requests.

## Fix

Look up the cached contract details (which already contain the resolved ConId) and copy both `PrimaryExch` and `ConId` into the newly created contract. This is consistent with how other security types like futures and options already handle contract creation.

The change is a small extension of the existing equity branch in `CreateContract()` around line 3347. `GetContractDetails` is called with `failIfNotFound: false` so the behavior is unchanged when no details are cached.

## Impact

- Fixes order routing for dual-listed equity symbols where SMART routing is ambiguous
- No impact on symbols that already resolve correctly (ConId is only set when > 0)
- Particularly relevant for EU users trading UCITS ETFs through IB where tickers are shared across exchanges