### PR TITLE
fix: warn once when outside-rth is set on combo orders

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1711,5 +1711,38 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             handler.Handle(now.AddMinutes(15).AddSeconds(1), IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode, "Test message 2");
             Assert.AreEqual(2, emittedCount, "Handler should emit again after throttle interval");
         }
+
+        [Test]
+        public void GetOutsideRegularTradingHoursComboWithFlagEmitsWarningOnce()
+        {
+            var brokerage = new InteractiveBrokersBrokerage();
+            var warnings = new List<BrokerageMessageEvent>();
+            brokerage.Message += (_, e) =>
+            {
+                if (e.Code == "ComboOrderOutsideRth")
+                {
+                    warnings.Add(e);
+                }
+            };
+
+            var flagged = new InteractiveBrokersOrderProperties { OutsideRegularTradingHours = true };
+            var unflagged = new InteractiveBrokersOrderProperties { OutsideRegularTradingHours = false };
+
+            brokerage.GetOutsideRegularTradingHours(OrderType.ComboLimit, flagged);
+            brokerage.GetOutsideRegularTradingHours(OrderType.ComboMarket, flagged);
+            brokerage.GetOutsideRegularTradingHours(OrderType.ComboLegLimit, flagged);
+            brokerage.GetOutsideRegularTradingHours(OrderType.Limit, flagged);
+            brokerage.GetOutsideRegularTradingHours(OrderType.ComboLimit, unflagged);
+
+            Assert.AreEqual(1, warnings.Count);
+        }
+
+        [Test]
+        public void GetOutsideRegularTradingHoursWithNullPropertiesAlwaysReturnsFalse(
+           [Values(OrderType.Limit, OrderType.LimitIfTouched, OrderType.StopMarket)] OrderType orderType)
+        {
+            var brokerage = new InteractiveBrokersBrokerage();
+            Assert.IsFalse(brokerage.GetOutsideRegularTradingHours(orderType, null));
+        }
     }
 }

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -265,6 +265,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <remarks>Ensures the warning is raised only once per application run to avoid spamming messages.</remarks>
         private bool _hasWarnedSafeMooExecution;
 
+        /// <summary>
+        /// Tracks whether the warning about IB ignoring OutsideRegularTradingHours on combo orders has already been sent.
+        /// </summary>
+        /// <remarks>Ensures the warning is raised only once per brokerage instance.</remarks>
+        private bool _hasWarnedComboOutsideRth;
+
         // Symbols that IB doesn't support ("No security definition has been found for the request")
         // We keep track of them to avoid flooding the logs with the same error/warning
         private readonly HashSet<string> _unsupportedAssets = new();
@@ -2893,19 +2899,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 quantity = order.Quantity;
             }
 
-            var outsideRth = false;
             var orderProperties = order.Properties as InteractiveBrokersOrderProperties;
-            if (order.Type == OrderType.Limit ||
-                order.Type == OrderType.LimitIfTouched ||
-                order.Type == OrderType.StopMarket ||
-                order.Type == OrderType.StopLimit ||
-                order.Type == OrderType.TrailingStop)
-            {
-                if (orderProperties != null)
-                {
-                    outsideRth = orderProperties.OutsideRegularTradingHours;
-                }
-            }
+            var outsideRth = GetOutsideRegularTradingHours(order.Type, orderProperties);
 
             var ibOrder = new IBApi.Order
             {
@@ -3489,6 +3484,36 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 default:
                     throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(OrderType));
             }
+        }
+
+        /// <summary>
+        /// Resolves the outside-RTH flag to send to IB, and emits a one-shot warning when the
+        /// user requested the flag on a combo order. IB server-side ignores the flag on combo
+        /// (BAG) orders (returns warning 2109), so we don't propagate it and tell the user once.
+        /// </summary>
+        internal bool GetOutsideRegularTradingHours(OrderType orderType, InteractiveBrokersOrderProperties orderProperties)
+        {
+            if (orderProperties?.OutsideRegularTradingHours != true)
+            {
+                return false;
+            }
+
+            if (orderType is OrderType.ComboMarket or OrderType.ComboLimit or OrderType.ComboLegLimit)
+            {
+                if (!_hasWarnedComboOutsideRth)
+                {
+                    _hasWarnedComboOutsideRth = true;
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "ComboOrderOutsideRth",
+                        "Interactive Brokers ignores the 'OutsideRegularTradingHours' order property on Combo Order Types."));
+                }
+                return false;
+            }
+
+            return orderType is OrderType.Limit 
+                or OrderType.LimitIfTouched
+                or OrderType.StopMarket
+                or OrderType.StopLimit
+                or OrderType.TrailingStop;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
Narrows `GetOutsideRegularTradingHours` so combo order types (`ComboMarket`, `ComboLimit`, `ComboLegLimit`) no longer propagate the `OutsideRegularTradingHours` property to IB, and emits a one-shot `BrokerageMessageEvent` (code `ComboOrderOutsideRth`, `BrokerageMessageType.Warning`) the first time a user submits a combo with the flag set.

#### Related PR(s)
N/A

#### Related Issue
closes #224

#### Motivation and Context
The original hypothesis was that Lean was silently dropping `OutsideRegularTradingHours` client-side for combo orders. Live testing on 2026-04-21 against IB Gateway (paper account) with both **equity-leg** and **option-leg** combos disproved this: IB server-side always ignores the flag on combo (BAG) orders and emits warning code **2109**:

> `Warning 2109, reqId <id>: Order Event Warning: Attribute 'Outside Regular Trading Hours' is ignored based on the order type and destination. PlaceOrder is now being processed.`

Examples that reproduce the warning on every submission:

**Equity combo (AAPL + MSFT, SMART-routed):**
```csharp
var aapl = AddEquity("AAPL", Resolution.Minute).Symbol;
var msft = AddEquity("MSFT", Resolution.Minute).Symbol;
var legs = new List<Leg>
{
    Leg.Create(aapl, 1),
    Leg.Create(msft, -1)
};
ComboMarketOrder(legs, 1, orderProperties: new InteractiveBrokersOrderProperties
{
    OutsideRegularTradingHours = true
});
```

**Option combo (vertical spread on SPY):**
```csharp
var spy = AddEquity("SPY", Resolution.Minute).Symbol;
var chain = OptionChain(spy);
var longCall  = chain.Where(c => c.Right == OptionRight.Call).OrderBy(c => c.Strike).First();
var shortCall = chain.Where(c => c.Right == OptionRight.Call && c.Strike > longCall.Strike).OrderBy(c => c.Strike).First();
var legs = new List<Leg>
{
    Leg.Create(longCall.Symbol, 1),
    Leg.Create(shortCall.Symbol, -1)
};
ComboLimitOrder(legs, 1, limitPrice: 1.50m, orderProperties: new InteractiveBrokersOrderProperties
{
    OutsideRegularTradingHours = true
});
```

In both cases the order itself is still accepted (goes to `Submitted` / `PreSubmitted`), but the outside-RTH attribute is stripped server-side, so combo legs will only trigger and fill during regular trading hours. Forwarding the flag to IB produces pure noise (one warning 2109 per submission) with zero behavioral change.

#### Requires Documentation Change
No

#### How Has This Been Tested?
- New NUnit test `GetOutsideRegularTradingHours_ComboWithFlag_EmitsWarningOnce` in `InteractiveBrokersBrokerageAdditionalTests` verifies:
  - the `ComboOrderOutsideRth` warning fires exactly once across multiple combo submissions with the flag set,
  - does not fire for non-combo order types,
  - does not fire for combo submissions without the flag.
- Manual verification against IB Gateway (paper, 2026-04-21): `ComboMarket` / `ComboLimit` / `ComboLegLimit` on equity-leg and option-leg combos — confirmed IB returns warning 2109 when the flag is forwarded, and no longer returns 2109 after this fix (flag dropped client-side).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention \`bug-<issue#>-<description>\` or \`feature-<issue#>-<description>\`