### PR TITLE
refactor: extract outside-rth decision into GetOutsideRegularTradingHours

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1711,5 +1711,30 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             handler.Handle(now.AddMinutes(15).AddSeconds(1), IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode, "Test message 2");
             Assert.AreEqual(2, emittedCount, "Handler should emit again after throttle interval");
         }
+
+        [TestCase(OrderType.Market, false, false)]
+        [TestCase(OrderType.Market, true, false)]
+        [TestCase(OrderType.Limit, true, true)]
+        [TestCase(OrderType.Limit, false, false)]
+        [TestCase(OrderType.ComboMarket, true, true)]
+        [TestCase(OrderType.ComboLimit, true, true)]
+        [TestCase(OrderType.ComboLegLimit, true, true)]
+        public void GetOutsideRegularTradingHoursFlagWithDifferentOrderTypes(OrderType orderType, bool orth, bool expected)
+        {
+            var brokerage = new InteractiveBrokersBrokerage();
+            var ibOP = new InteractiveBrokersOrderProperties { OutsideRegularTradingHours = orth };
+
+            var actual = brokerage.GetOutsideRegularTradingHours(orderType, ibOP);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void GetOutsideRegularTradingHoursWithNullPropertiesAlwaysReturnsFalse(
+           [Values(OrderType.Limit, OrderType.LimitIfTouched, OrderType.StopMarket)] OrderType orderType)
+        {
+            var brokerage = new InteractiveBrokersBrokerage();
+            Assert.IsFalse(brokerage.GetOutsideRegularTradingHours(orderType, null));
+        }
     }
 }

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -1711,38 +1711,5 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             handler.Handle(now.AddMinutes(15).AddSeconds(1), IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode, "Test message 2");
             Assert.AreEqual(2, emittedCount, "Handler should emit again after throttle interval");
         }
-
-        [Test]
-        public void GetOutsideRegularTradingHoursComboWithFlagEmitsWarningOnce()
-        {
-            var brokerage = new InteractiveBrokersBrokerage();
-            var warnings = new List<BrokerageMessageEvent>();
-            brokerage.Message += (_, e) =>
-            {
-                if (e.Code == "ComboOrderOutsideRth")
-                {
-                    warnings.Add(e);
-                }
-            };
-
-            var flagged = new InteractiveBrokersOrderProperties { OutsideRegularTradingHours = true };
-            var unflagged = new InteractiveBrokersOrderProperties { OutsideRegularTradingHours = false };
-
-            brokerage.GetOutsideRegularTradingHours(OrderType.ComboLimit, flagged);
-            brokerage.GetOutsideRegularTradingHours(OrderType.ComboMarket, flagged);
-            brokerage.GetOutsideRegularTradingHours(OrderType.ComboLegLimit, flagged);
-            brokerage.GetOutsideRegularTradingHours(OrderType.Limit, flagged);
-            brokerage.GetOutsideRegularTradingHours(OrderType.ComboLimit, unflagged);
-
-            Assert.AreEqual(1, warnings.Count);
-        }
-
-        [Test]
-        public void GetOutsideRegularTradingHoursWithNullPropertiesAlwaysReturnsFalse(
-           [Values(OrderType.Limit, OrderType.LimitIfTouched, OrderType.StopMarket)] OrderType orderType)
-        {
-            var brokerage = new InteractiveBrokersBrokerage();
-            Assert.IsFalse(brokerage.GetOutsideRegularTradingHours(orderType, null));
-        }
     }
 }

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -2893,19 +2893,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 quantity = order.Quantity;
             }
 
-            var outsideRth = false;
             var orderProperties = order.Properties as InteractiveBrokersOrderProperties;
-            if (order.Type == OrderType.Limit ||
-                order.Type == OrderType.LimitIfTouched ||
-                order.Type == OrderType.StopMarket ||
-                order.Type == OrderType.StopLimit ||
-                order.Type == OrderType.TrailingStop)
-            {
-                if (orderProperties != null)
-                {
-                    outsideRth = orderProperties.OutsideRegularTradingHours;
-                }
-            }
+            var outsideRth = GetOutsideRegularTradingHours(order.Type, orderProperties);
 
             var ibOrder = new IBApi.Order
             {
@@ -3489,6 +3478,28 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 default:
                     throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(OrderType));
             }
+        }
+
+        /// <summary>
+        /// Resolves the outside-RTH flag to send to IB, and emits a one-shot warning when the
+        /// user requested the flag on a combo order. IB server-side ignores the flag on combo
+        /// (BAG) orders (returns warning 2109), so we don't propagate it and tell the user once.
+        /// </summary>
+        internal bool GetOutsideRegularTradingHours(OrderType orderType, InteractiveBrokersOrderProperties orderProperties)
+        {
+            if (orderProperties?.OutsideRegularTradingHours != true)
+            {
+                return false;
+            }
+
+            return orderType is OrderType.Limit
+                or OrderType.LimitIfTouched
+                or OrderType.StopMarket
+                or OrderType.StopLimit
+                or OrderType.TrailingStop
+                or OrderType.ComboMarket
+                or OrderType.ComboLimit
+                or OrderType.ComboLegLimit;
         }
 
         /// <summary>

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -265,12 +265,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <remarks>Ensures the warning is raised only once per application run to avoid spamming messages.</remarks>
         private bool _hasWarnedSafeMooExecution;
 
-        /// <summary>
-        /// Tracks whether the warning about IB ignoring OutsideRegularTradingHours on combo orders has already been sent.
-        /// </summary>
-        /// <remarks>Ensures the warning is raised only once per brokerage instance.</remarks>
-        private bool _hasWarnedComboOutsideRth;
-
         // Symbols that IB doesn't support ("No security definition has been found for the request")
         // We keep track of them to avoid flooding the logs with the same error/warning
         private readonly HashSet<string> _unsupportedAssets = new();
@@ -2899,8 +2893,19 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 quantity = order.Quantity;
             }
 
+            var outsideRth = false;
             var orderProperties = order.Properties as InteractiveBrokersOrderProperties;
-            var outsideRth = GetOutsideRegularTradingHours(order.Type, orderProperties);
+            if (order.Type == OrderType.Limit ||
+                order.Type == OrderType.LimitIfTouched ||
+                order.Type == OrderType.StopMarket ||
+                order.Type == OrderType.StopLimit ||
+                order.Type == OrderType.TrailingStop)
+            {
+                if (orderProperties != null)
+                {
+                    outsideRth = orderProperties.OutsideRegularTradingHours;
+                }
+            }
 
             var ibOrder = new IBApi.Order
             {
@@ -3484,36 +3489,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 default:
                     throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(OrderType));
             }
-        }
-
-        /// <summary>
-        /// Resolves the outside-RTH flag to send to IB, and emits a one-shot warning when the
-        /// user requested the flag on a combo order. IB server-side ignores the flag on combo
-        /// (BAG) orders (returns warning 2109), so we don't propagate it and tell the user once.
-        /// </summary>
-        internal bool GetOutsideRegularTradingHours(OrderType orderType, InteractiveBrokersOrderProperties orderProperties)
-        {
-            if (orderProperties?.OutsideRegularTradingHours != true)
-            {
-                return false;
-            }
-
-            if (orderType is OrderType.ComboMarket or OrderType.ComboLimit or OrderType.ComboLegLimit)
-            {
-                if (!_hasWarnedComboOutsideRth)
-                {
-                    _hasWarnedComboOutsideRth = true;
-                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "ComboOrderOutsideRth",
-                        "Interactive Brokers ignores the 'OutsideRegularTradingHours' order property on Combo Order Types."));
-                }
-                return false;
-            }
-
-            return orderType is OrderType.Limit 
-                or OrderType.LimitIfTouched
-                or OrderType.StopMarket
-                or OrderType.StopLimit
-                or OrderType.TrailingStop;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
Consolidates the `OrderType` whitelist for `OutsideRegularTradingHours` into a new `GetOutsideRegularTradingHours` helper and includes `ComboMarket` / `ComboLimit` / `ComboLegLimit` in the whitelist so combo orders now propagate the flag to IB. This PR also reverts the earlier #225 which was based on the incorrect assumption that IB server-side strips the flag on every BAG order.

#### Related PR(s)
Reverts #225.

#### Related Issue
#224

#### Motivation and Context
The original fix (#225) dropped the flag client-side for all combo types and emitted a one-shot warning, based on a test where warning **2109** (`Attribute 'Outside Regular Trading Hours' is ignored based on the order type and destination`) fired on a SMART-routed equity combo. The issue reporter pushed back that SPX option combos do honor the flag against the native IB API. Re-testing with an `IndexOption` (SPXW) vertical `ComboLimit` on IB paper confirmed **no warning 2109** is returned and the legs are accepted with the flag intact - so dropping it client-side was wrong for this case. The refactor keeps the helper (clean call site in `ConvertOrder`) but adds combo types to the whitelist.

IB paper-gateway trace for the retry (SPXW 2026-04-23 C 7150 / C 7130 vertical, `ComboLimit`, `OutsideRegularTradingHours = true`):

```
Submit Order: (1) New ComboLimit order for -1 units of SPXW  260423C07150000  Status: Unprocessed
Submit Order: (2) New ComboLimit order for 1 unit of SPXW  260423C07130000  Status: Unprocessed
InteractiveBrokersBrokerage.PlaceOrder(): Symbol: SPXW  260423C07130000 Quantity: 1. Id: 2. BrokerId: 12
InteractiveBrokersBrokerage.HandleOpenOrder(): OrderId: 12, Contract: BAG SPX USD SMART, OrderStatus: PreSubmitted
InteractiveBrokersBrokerage.HandleOrderStatusUpdates(): OrderId: 12, Status: PreSubmitted, Filled: 0, Remaining: 1, PermId: 1411989318
OrderEvent: Symbol: SPXW  260423C07150000 Status: Submitted
OrderEvent: Symbol: SPXW  260423C07130000 Status: Submitted
```

No 2109 emitted; both legs reach `PreSubmitted` / `Submitted`.

Example:
```csharp
var spx = AddIndex("SPX", Resolution.Minute).Symbol;
var option = AddIndexOption(spx, "SPXW", Resolution.Minute);
option.SetFilter(u => u.Strikes(-5, 5).Expiration(0, 1));
// ...
var legs = new List<Leg>
{
    Leg.Create(shortCall.Symbol, -1),
    Leg.Create(longCall.Symbol, 1)
};
ComboLimitOrder(legs, 1, limitPrice: 0.10m, orderProperties: new InteractiveBrokersOrderProperties
{
    OutsideRegularTradingHours = true
});
```

#### Requires Documentation Change
No

#### How Has This Been Tested?
- New NUnit tests in `InteractiveBrokersBrokerageAdditionalTests`:
  - `GetOutsideRegularTradingHoursFlagWithDifferentOrderTypes`
  - `GetOutsideRegularTradingHoursWithNullPropertiesAlwaysReturnsFalse`
- Manual: IB paper gateway, `SecurityType.IndexOption` (SPXW) vertical `ComboLimit` with `OutsideRegularTradingHours = true` - no warning 2109, both legs reach `Submitted` (trace above).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention \`bug-<issue#>-<description>\` or \`feature-<issue#>-<description>\`