### PR TITLE
Fix IB error 201 when FA group filter is set with a per-order Account override

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageTests.cs
@@ -774,6 +774,73 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             return holdings;
         }
 
+        /// <summary>
+        /// Live regression test for IB error 201 ("Invalid account number") when the FA group
+        /// filter is active and an order also carries a per-order
+        /// <see cref="InteractiveBrokersOrderProperties.Account"/> override. The order should be
+        /// accepted (<c>Status: Submitted</c>) and route to the single sub-account.
+        /// </summary>
+        /// <remarks>
+        /// Validated end-to-end against a live IB Financial Advisor master account: TWS shows the
+        /// resulting order under the "IndBrokerage" allocation (single-account routing) rather
+        /// than under the FA group's allocation method, confirming the per-order
+        /// <c>Account</c> override took effect. A complementary scenario with no Account override
+        /// (using only the global FA group filter) was also verified to still route as a group
+        /// order in the same algorithm run, proving the fix did not regress the default path.
+        /// </remarks>
+        [Test, Explicit("Requires IB master account with FA group 'TestGroup1' configured and a sub-account belonging to that group; supply ib-account (master) and ib-fa-test-sub-account (sub-account).")]
+        public void PlaceLimitOrderWithFaGroupFilterAndAccountOverride()
+        {
+            var masterAccount = Config.Get("ib-account");
+            Assert.IsTrue(InteractiveBrokersBrokerage.IsMasterAccount(masterAccount), $"Expected master account '{masterAccount}' to be recognized as a master account, but it was not.");
+
+            var subAccount = Config.Get("ib-fa-test-sub-account");
+            Assert.IsFalse(string.IsNullOrEmpty(subAccount), "Config 'ib-fa-test-sub-account' must be set to a valid sub-account belonging to the FA master.");
+
+            // Should Disconnect and dispose to prevent action of [SetUp] method
+            _interactiveBrokersBrokerage.Dispose();
+            Assert.IsFalse(_interactiveBrokersBrokerage.IsConnected, "Brokerage should be disconnected after Dispose");
+
+            // Apply the FA group filter and rebuild the brokerage so the filter takes effect at construction.
+            Config.Set("ib-financial-advisors-group-filter", "TestGroup1");
+            _interactiveBrokersBrokerage = CreateBrokerage();
+
+            var submittedEvent = new AutoResetEvent(false);
+            OrderEvent rejection = null;
+            void OnOrdersStatusChanged(object _, List<OrderEvent> events)
+            {
+                foreach (var orderEvent in events)
+                {
+                    if (orderEvent.Status == OrderStatus.Submitted)
+                    {
+                        submittedEvent.Set();
+                    }
+                    if (orderEvent.Status == OrderStatus.Invalid)
+                    {
+                        rejection = orderEvent;
+                    }
+                }
+            }
+
+            _interactiveBrokersBrokerage.OrdersStatusChanged += OnOrdersStatusChanged;
+
+            // Far-from-market limit so the order sits as Submitted rather than filling.
+            var properties = new InteractiveBrokersOrderProperties { Account = subAccount };
+            var order = new LimitOrder(Symbols.SPY, 10, 100.00m, DateTime.UtcNow, tag: string.Empty, properties: properties);
+            _orders.Add(order);
+
+            Assert.IsTrue(_interactiveBrokersBrokerage.PlaceOrder(order), "Failed to place limit order.");
+
+            var submitted = submittedEvent.WaitOne(TimeSpan.FromSeconds(20));
+
+            // Cleanup: cancel the working order regardless of outcome.
+            _interactiveBrokersBrokerage.CancelOrder(order);
+            _interactiveBrokersBrokerage.OrdersStatusChanged -= OnOrdersStatusChanged;
+
+            Assert.IsNull(rejection, $"Order should not be rejected by IB. Got: {rejection?.Message}");
+            Assert.IsTrue(submitted, "Order did not reach Submitted status within 20 seconds.");
+        }
+
 
         [Explicit("Ignore a test")]
         public void DoesNotLoopEndlesslyIfGetCashBalanceAlwaysThrows()

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersFaGroupOrderConversionTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersFaGroupOrderConversionTests.cs
@@ -1,0 +1,141 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using IBApi;
+using NUnit.Framework;
+using QuantConnect.Brokerages.InteractiveBrokers;
+using QuantConnect.Orders;
+using IB = QuantConnect.Brokerages.InteractiveBrokers.Client;
+using LeanOrder = QuantConnect.Orders.Order;
+
+namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
+{
+    /// <summary>
+    /// Hermetic regression test for IB error 201 ("Invalid account number") when an FA group
+    /// filter is active and an order also carries a per-order <see cref="InteractiveBrokersOrderProperties.Account"/>
+    /// override. The fixture invokes <c>InteractiveBrokersBrokerage.ConvertOrder</c> via reflection
+    /// (the assembly already exposes its internals to this test project) so the test can run in CI
+    /// without a live IB Gateway / TWS connection.
+    /// </summary>
+    /// <remarks>
+    /// Validated end-to-end against a live IB Financial Advisor master account: the same
+    /// (filter set + per-order Account override) configuration that produced IB error 201 before
+    /// the fix is accepted with <c>Status: Submitted</c> after the fix. A companion two-order
+    /// scenario (one with an Account override, one without) confirmed both branches route as
+    /// intended in TWS — the per-order override appears under the "IndBrokerage" allocation, the
+    /// default order appears under the configured FA group's allocation method.
+    /// </remarks>
+    [TestFixture]
+    public class InteractiveBrokersFaGroupOrderConversionTests
+    {
+        private const string FaMasterAccount = "F1234567";    // any account containing 'F' is a master account
+        private const string FaGroupName     = "TestGroup1";
+        private const string AgentDescription = "I";          // IB.AgentDescription.Individual
+
+        private static readonly FieldInfo AccountField =
+            typeof(InteractiveBrokersBrokerage).GetField("_account", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo AgentDescriptionField =
+            typeof(InteractiveBrokersBrokerage).GetField("_agentDescription", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo FaFilterField =
+            typeof(InteractiveBrokersBrokerage).GetField("_financialAdvisorsGroupFilter", BindingFlags.Static | BindingFlags.NonPublic);
+        private static readonly MethodInfo ConvertOrderMethod =
+            typeof(InteractiveBrokersBrokerage).GetMethod(
+                "ConvertOrder",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(List<LeanOrder>), typeof(Contract), typeof(int) },
+                modifiers: null);
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Reset the static FA filter so other fixtures aren't polluted.
+            FaFilterField.SetValue(null, null);
+        }
+
+        /// <summary>
+        /// When the FA group filter is configured and the order carries a per-order
+        /// <c>Account</c> override, the resulting <see cref="IBApi.Order"/> must have
+        /// <c>Account</c> set and <c>FaGroup</c>/<c>FaMethod</c> cleared. The two are mutually
+        /// exclusive on the wire; sending them together produces IB error 201
+        /// ("Invalid account number").
+        /// </summary>
+        [Test]
+        public void LimitOrder_WithAccountOverrideAndGroupFilter_AccountWinsAndFaGroupCleared()
+        {
+            // Arrange
+            var brokerage = CreateOfflineBrokerage();
+            FaFilterField.SetValue(null, FaGroupName);
+
+            const string overrideAccount = "TestSubAccount";
+            var props = new InteractiveBrokersOrderProperties
+            {
+                Account = overrideAccount,
+                FaGroup = string.Empty,
+                FaProfile = string.Empty,
+                FaMethod = string.Empty,
+            };
+
+            var leanOrder = new LimitOrder(Symbols.SPY, 10m, 100.00m,
+                new DateTime(2026, 1, 1, 15, 0, 0, DateTimeKind.Utc),
+                tag: "",
+                properties: props);
+
+            var ibContract = new Contract
+            {
+                Symbol = "SPY", SecType = IB.SecurityType.Stock, Exchange = "SMART", Currency = "USD"
+            };
+
+            // Act
+            var ibOrder = (IBApi.Order)ConvertOrderMethod.Invoke(
+                brokerage,
+                new object[] { new List<LeanOrder> { leanOrder }, ibContract, 1 });
+
+            // Assert
+            Assert.AreEqual(overrideAccount, ibOrder.Account,
+                "When orderProperties.Account is supplied, ibOrder.Account must reflect that override.");
+            Assert.IsTrue(string.IsNullOrEmpty(ibOrder.FaGroup),
+                "FaGroup must be cleared when an Account override is supplied (IB rejects Account+FaGroup together with error 201).");
+            Assert.IsTrue(string.IsNullOrEmpty(ibOrder.FaMethod),
+                "FaMethod must be cleared alongside FaGroup when an Account override is supplied.");
+        }
+
+        /// <summary>
+        /// Builds an <see cref="InteractiveBrokersBrokerage"/> with just enough state for
+        /// <c>ConvertOrder</c> to run without opening a TCP connection to TWS / IB Gateway.
+        /// </summary>
+        private static InteractiveBrokersBrokerage CreateOfflineBrokerage()
+        {
+            var brokerage = new InteractiveBrokersBrokerage();
+
+            AccountField.SetValue(brokerage, FaMasterAccount);
+            AgentDescriptionField.SetValue(brokerage, AgentDescription);
+
+            // Stub contract-details provider — returns a deterministic min tick of 0.01 so the
+            // limit price round-trips cleanly through NormalizePriceToBrokerage.
+            brokerage._contractSpecificationService = new IB.ContractSpecificationService(
+                (contract, ticker, failIfNotFound) => new ContractDetails
+                {
+                    Contract = contract,
+                    MinTick = 0.01
+                });
+
+            return brokerage;
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -3025,8 +3025,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                     if (!string.IsNullOrWhiteSpace(orderProperties.Account))
                     {
-                        // order for a single managed account
+                        // order for a single managed account.
+                        // IB requires Account, FaGroup and FaProfile to be mutually exclusive on the wire —
+                        // if both Account and FaGroup are sent, IB rejects with error 201 "Invalid account
+                        // number". Clear any FaGroup/FaMethod that the global financial-advisors group
+                        // filter assigned earlier so the per-order Account override is unambiguous.
                         ibOrder.Account = orderProperties.Account;
+                        ibOrder.FaGroup = string.Empty;
+                        ibOrder.FaMethod = string.Empty;
                     }
                     else if (!string.IsNullOrWhiteSpace(orderProperties.FaGroup) || !string.IsNullOrWhiteSpace(orderProperties.FaProfile))
                     {


### PR DESCRIPTION
#### Description
When `ib-financial-advisors-group-filter` is configured and an order's `InteractiveBrokersOrderProperties.Account` is set to a specific sub-account, `ConvertOrder` previously left `FaGroup` populated from the global filter. The outbound IB order then carried both `Account` and `FaGroup`, and IB rejects that combination with error 201 "Invalid account number" — `Account`, `FaGroup`, and `FaProfile` are mutually exclusive on the wire.

<img width="1912" height="501" alt="image" src="https://github.com/user-attachments/assets/964f9a6a-077b-41ff-8209-06784319a800" />

The pre-existing warning at the top of this block already calls these fields out as mutually exclusive, and the XML doc on `InteractiveBrokersOrderProperties.Account` states the same. This change makes the implementation match: when the per-order `Account` override is honored, clear any `FaGroup`/`FaMethod` that was assigned earlier in the method from the global financial-advisors group filter.

#### Related PRs
- https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/164

#### Related Issue
Closes #228

#### Motivation and Context
Algorithms running against an FA master account that need to route specific orders to a single sub-account (rather than a group) cannot do so today — the resulting IB order is rejected with error 201 because `FaGroup` from the global filter and `Account` from the per-order override are sent together. Both `ConvertOrder`'s existing warning text and the public XML doc on `InteractiveBrokersOrderProperties.Account` already say these fields are mutually exclusive; this PR makes the implementation match the contract.

#### Requires Documentation Change
No.

#### How Has This Been Tested?

**Hermetic regression test** — `InteractiveBrokersFaGroupOrderConversionTests.LimitOrder_WithAccountOverrideAndGroupFilter_AccountWinsAndFaGroupCleared` invokes `ConvertOrder` directly via reflection (no live IB connection) and asserts `Account` is set and `FaGroup`/`FaMethod` are cleared when both an FA group filter and a per-order `Account` override are supplied. Fails before this commit, passes after.


**Live `[Explicit]` integration test** — `PlaceLimitOrderWithFaGroupFilterAndAccountOverride` in `InteractiveBrokersBrokerageTests.cs`, modeled on the existing `PlaceMarketOrderWithDifferentFAGroupFilter` pattern. Sets the FA group filter via `Config.Set`, places a far-from-market `LimitOrder` with `InteractiveBrokersOrderProperties.Account` pointing at a sub-account, asserts the order reaches `Submitted` and is not rejected. Marked `[Explicit]` because paper trading does not simulate FA-group routing — only live IB FA accounts do.

<img width="548" height="144" alt="image" src="https://github.com/user-attachments/assets/14049d0c-4cce-4a1c-a84e-61e55f7bd3c2" />

**End-to-end live verification** against an IB Financial Advisor master account (TWS observation):

- The exact configuration that previously produced IB error 201 (filter set + per-order `Account` override) is now accepted with `Status: Submitted`. No `[Financial Advisor Warning]` window event from IB Gateway for this order.

The test algorithm:
``` 
// Order #1 - per-order Account override (the bug scenario).
// Before the fix this combination produced IB error 201 because FaGroup from the
// global filter and Account from the override were sent together.
var overrideProps = new InteractiveBrokersOrderProperties { Account = SubAccount };
var orderWithOverride = LimitOrder(_symbol, 10, limitPrice, tag: "AccountOverride", orderProperties: overrideProps);
Log($"Placed override order: {orderWithOverride} (Account={SubAccount})");

// Order #2 - no per-order override; routes through the global FA group filter.
// Used as the no-regression control: should still appear under the group's allocation in TWS.
var orderWithGroupOnly = LimitOrder(_symbol, 10, limitPrice, tag: "GroupFilterOnly");
Log($"Placed group-filter order: {orderWithGroupOnly}");
```

<img width="1884" height="725" alt="image" src="https://github.com/user-attachments/assets/8e2efc7e-5cd2-4042-a4f6-0841736fef0a" />



#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`