### PR TITLE
Run CI on self-hosted runners

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -4,20 +4,31 @@ on:
   push:
     branches: ['*']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
+        env:
+          QC_IB_ACCOUNT: ${{ secrets.QC_IB_ACCOUNT }}
+          QC_IB_USER_NAME: ${{ secrets.QC_IB_USER_NAME }}
+          QC_IB_PASSWORD: ${{ secrets.QC_IB_PASSWORD }}
+          QC_IB_TRADING_MODE: ${{ secrets.QC_IB_TRADING_MODE }}
+          QC_IB_AGENT_DESCRIPTION: ${{ secrets.QC_IB_AGENT_DESCRIPTION }}
+          QC_IB_TWS_DIR: ${{ secrets.QC_IB_TWS_DIR }}
+          QC_IB_ENABLE_DELAYED_STREAMING_DATA: ${{ secrets.QC_IB_ENABLE_DELAYED_STREAMING_DATA }}
+          QC_IB_HOST: ${{ secrets.QC_IB_HOST }}
+          QC_JOB_USER_ID: ${{ secrets.JOB_USER_ID }}
+          QC_API_ACCESS_TOKEN: ${{ secrets.API_ACCESS_TOKEN }}
+          JOB_ORGANIZATION_ID: ${{ secrets.JOB_ORGANIZATION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Liberate disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch
@@ -38,14 +49,10 @@ jobs:
       - name: Move Lean
         run: mv Lean ../Lean
 
-      - name: Run Image
-        uses: addnab/docker-run-action@v3
-        with:
-          image: quantconnect/lean:foundation
-          options: --workdir /__w/Lean.Brokerages.InteractiveBrokers/Lean.Brokerages.InteractiveBrokers -v /home/runner/work:/__w -e QC_IB_ACCOUNT=${{ secrets.QC_IB_ACCOUNT }} -e QC_IB_USER_NAME=${{ secrets.QC_IB_USER_NAME }} -e QC_IB_PASSWORD=${{ secrets.QC_IB_PASSWORD }} -e QC_IB_TRADING_MODE=${{ secrets.QC_IB_TRADING_MODE }} -e QC_IB_AGENT_DESCRIPTION=${{ secrets.QC_IB_AGENT_DESCRIPTION }} -e QC_IB_TWS_DIR=${{ secrets.QC_IB_TWS_DIR }} -e QC_IB_ENABLE_DELAYED_STREAMING_DATA=${{ secrets.QC_IB_ENABLE_DELAYED_STREAMING_DATA }} -e QC_IB_HOST=${{ secrets.QC_IB_HOST }} -e QC_JOB_USER_ID=${{ secrets.JOB_USER_ID }} -e QC_API_ACCESS_TOKEN=${{ secrets.API_ACCESS_TOKEN }} -e JOB_ORGANIZATION_ID=${{ secrets.JOB_ORGANIZATION_ID }}
-          shell: bash
-          run: |
-            # Build
-            dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.InteractiveBrokersBrokerage.sln && \
-            # Run Tests
-            dotnet test ./QuantConnect.InteractiveBrokersBrokerage.Tests/bin/Release/QuantConnect.Brokerages.InteractiveBrokers.Tests.dll
+      - name: Run build and tests
+        run: |
+          # Build
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.InteractiveBrokersBrokerage.sln && \
+          # Run Tests
+          dotnet test ./QuantConnect.InteractiveBrokersBrokerage.Tests/bin/Release/QuantConnect.Brokerages.InteractiveBrokers.Tests.dll
+


### PR DESCRIPTION
Mirrors QuantConnect/Lean#9540 (`c57fd18b`): build/test now runs on **self-hosted** runners inside a job-level `quantconnect/lean:foundation` container (`--cpus 12 --memory 12g`) instead of GitHub-hosted ubuntu + `addnab/docker-run-action`. Drops the disk-cleanup step and docker-run wrapper (build/test run as a normal step in the container; secrets via container `env`), and adds a `concurrency` group (cancel-in-progress). YAML validated; needs a runner to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)