### PR TITLE
Fix algorithm crash on IB error 300 during market-data unsubscribe

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageHandleErrorTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageHandleErrorTests.cs
@@ -1,0 +1,82 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.InteractiveBrokers;
+using IB = QuantConnect.Brokerages.InteractiveBrokers.Client;
+
+namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
+{
+    [TestFixture]
+    public class InteractiveBrokersBrokerageHandleErrorTests
+    {
+        // error 300 ("Can't find EId with tickerId:N") is IB rejecting a cancelMktData for a ticker
+        // it has no active subscription for. It must only be suppressed when it targets a market-data
+        // ticker we have already unsubscribed (the async cancelMktData races the removal, common during
+        // teardown); a 300 for a ticker we still believe is active must still surface to the user.
+        [TestCase(false, 0, TestName = "HandleError_Code300_ForUnsubscribedTicker_IsIgnored")]
+        [TestCase(true, 1, TestName = "HandleError_Code300_ForSubscribedTicker_IsSurfaced")]
+        public void HandleErrorSuppressesCode300OnlyForUnsubscribedTickers(bool stillSubscribed, int expectedMessageCount)
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            const int tickerId = 12;
+
+            // seed the request information for the ticker as a market-data subscription request
+            var requestInformationType = typeof(InteractiveBrokersBrokerage).GetNestedType("RequestInformation", BindingFlags.NonPublic);
+            var requestType = typeof(InteractiveBrokersBrokerage).GetNestedType("RequestType", BindingFlags.NonPublic);
+            var requestInformation = Activator.CreateInstance(requestInformationType);
+            requestInformationType.GetProperty("RequestId").SetValue(requestInformation, tickerId);
+            requestInformationType.GetProperty("RequestType").SetValue(requestInformation, Enum.Parse(requestType, "Subscription"));
+            requestInformationType.GetProperty("Message").SetValue(requestInformation, $"[Id={tickerId}] Subscribe: HSI (IND HSI HKD hkfe   0 )");
+            ((IDictionary)GetPrivateFieldValue(brokerage, "_requestInformation"))[tickerId] = requestInformation;
+
+            if (stillSubscribed)
+            {
+                // ticker still tracked: the 300 is unexpected and must be surfaced
+                var subscriptionEntryType = typeof(InteractiveBrokersBrokerage).GetNestedType("SubscriptionEntry", BindingFlags.NonPublic);
+                var subscriptionEntry = Activator.CreateInstance(subscriptionEntryType);
+                ((IDictionary)GetPrivateFieldValue(brokerage, "_subscribedTickers"))[tickerId] = subscriptionEntry;
+            }
+
+            var messages = new List<BrokerageMessageEvent>();
+            void OnMessage(object _, BrokerageMessageEvent message) => messages.Add(message);
+            brokerage.Message += OnMessage;
+
+            var errorEvent = new IB.ErrorEventArgs(
+                id: tickerId,
+                time: 0,
+                code: 300,
+                message: "Can't find EId with tickerId:12");
+            brokerage.HandleError(this, errorEvent);
+
+            brokerage.Message -= OnMessage;
+
+            Assert.AreEqual(expectedMessageCount, messages.Count(m => m.Code == "300"));
+        }
+
+        private static object GetPrivateFieldValue(object instance, string name)
+        {
+            return instance.GetType()
+                .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(instance);
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -2015,6 +2015,18 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             Log.Trace($"InteractiveBrokersBrokerage.HandleError(): RequestId: {requestId} ErrorCode: {errorCode} - {errorMsg}");
 
+            // error 300: "Can't find EId with tickerId:N" - IB rejecting a cancelMktData for a ticker
+            // it has no active subscription for. This is benign only when it's a market-data ticker we
+            // have already unsubscribed (the async cancel races the removal, common during teardown).
+            // In that case _subscribedTickers no longer has the id; otherwise let the error surface.
+            if (errorCode == 300
+                && requestInfo?.RequestType == RequestType.Subscription
+                && !_subscribedTickers.ContainsKey(requestId))
+            {
+                Log.Trace($"InteractiveBrokersBrokerage.HandleError(): Ignoring benign cancel-market-data error for an already-unsubscribed ticker. ErrorCode: {errorCode} - {errorMsg}");
+                return;
+            }
+
             if (errorCode == 2105 || errorCode == 2103)
             {
                 // 'connection is broken': if we haven't already let's trigger a gateway restart


### PR DESCRIPTION
## Description

When unsubscribing a security, `Unsubscribe()` calls `cancelMktData(id)` and then immediately removes the ticker from `_subscribedTickers`. IB can reply **asynchronously** with error **300 (`Can't find EId with tickerId:N`)** because it no longer has an active market-data subscription for that ticker. This is a benign race, common during teardown.

Because code `300` was in the fatal `ErrorCodes` set (and not filtered), it was published as a brokerage error, surfaced as a `RuntimeError`, and crashed the algorithm on shutdown.

Observed in a live deployment unsubscribing an HSI index subscription during shutdown:

```
InteractiveBrokersBrokerage.HandleError(): RequestId: 12 ErrorCode: 300 - Can't find EId with tickerId:12. Origin: [Id=12] Subscribe: HSI (IND HSI HKD hkfe   0 )
ERROR:: Brokerage.OnMessage(): Error - Code: 300 - Can't find EId with tickerId:12 ...
ERROR:: Extensions.SetRuntimeError(): RuntimeError ... Context: Brokerage Error System.Exception: Can't find EId with tickerId:12 ...
```

## Fix

Suppress error `300` **only** when it targets a market-data subscription ticker we have already unsubscribed (i.e. the request was a `Subscription` and the id is no longer in `_subscribedTickers`). A `300` for a ticker we still believe is active is left to surface as before, so genuine problems are not hidden.

## Tests

Added `InteractiveBrokersBrokerageHandleErrorTests` driving `HandleError` with a 300 for:
- an already-unsubscribed ticker → suppressed (no brokerage message), and
- a still-subscribed ticker → surfaced (brokerage message emitted).

Both pass. The fixture is a pure unit test (no IB Gateway required).