### PR TITLE
Add KOSPI 200 Index (KM) Futures support

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersSymbolMapperTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersSymbolMapperTests.cs
@@ -81,6 +81,10 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 var audFuture = Symbol.CreateFuture("6A", Market.CME, new DateTime(2055, 12, 15));
                 yield return new(audFuture, "AUD");
                 yield return new(Symbol.CreateOption(audFuture, Market.CME, OptionStyle.European, OptionRight.Call, 0.645m, new DateTime(2025, 12, 05)), "AUD");
+
+                // KOSPI 200 future: LEAN root "KM" maps to IB's "K200"
+                var kospi200Future = Symbol.CreateFuture(Futures.Indices.Kospi200, Market.KRX, new DateTime(2025, 12, 11));
+                yield return new(kospi200Future, "K200");
             }
         }
 
@@ -91,6 +95,24 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             var brokerageSymbol = mapper.GetBrokerageSymbol(leanSymbol);
             Assert.AreEqual(expectedBrokerageSymbol, brokerageSymbol);
+        }
+
+        [Test]
+        public void MapsKospi200Future()
+        {
+            var mapper = new InteractiveBrokersSymbolMapper(TestGlobals.MapFileProvider);
+
+            var expiry = new DateTime(2025, 12, 11);
+            var leanSymbol = mapper.GetLeanSymbol("K200", SecurityType.Future, Market.KRX, expiry);
+            Assert.AreEqual(Futures.Indices.Kospi200, leanSymbol.ID.Symbol);
+            Assert.AreEqual(SecurityType.Future, leanSymbol.ID.SecurityType);
+            Assert.AreEqual(Market.KRX, leanSymbol.ID.Market);
+            Assert.AreEqual(expiry, leanSymbol.ID.Date);
+
+            Assert.AreEqual("K200", mapper.GetBrokerageSymbol(leanSymbol));
+
+            // KOSPI 200 futures are routed to IB's "KSE" exchange
+            Assert.AreEqual("KSE", InteractiveBrokersBrokerage.GetSymbolExchange(SecurityType.Future, Market.KRX));
         }
 
         [TestCase("AAPL", "AAPL")]

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokers/IB-symbol-map.json
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokers/IB-symbol-map.json
@@ -21,7 +21,8 @@
     "ESTX50": "FESX",
     "DAX": "FDAX",
     "DDAX": "FDIV",
-    "TDX": "FTDX"
+    "TDX": "FTDX",
+    "K200": "KM"
   },
   "Index": {
     "ESTX50": "SX5E",

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokers/IB-symbol-map.json
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokers/IB-symbol-map.json
@@ -38,6 +38,7 @@
     "DTX": "DJTTR",
     "SML": "SP600",
     "CVK": "SPSV",
-    "WFVK.IV": "DWCF"
+    "WFVK.IV": "DWCF",
+    "K200": "KM"
   }
 }

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -3374,6 +3374,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     contract.Exchange = "OSE.JPN";
                 }
+                else if(string.Equals(symbol.ID.Market, Market.KRX, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    contract.Exchange = "KSE";
+                }
                 else
                 {
                     contract.Exchange = IndexSymbol.GetIndexExchange(symbol);
@@ -4319,7 +4323,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 (securityType == SecurityType.Forex && (market == Market.Oanda || market == Market.InteractiveBrokers)) ||
                 (securityType == SecurityType.Option && market == Market.USA) ||
                 (securityType == SecurityType.IndexOption && market == Market.USA) ||
-                (securityType == SecurityType.Index && (market == Market.USA || market == Market.EUREX || market == Market.OSE || market == Market.HKFE)) ||
+                (securityType == SecurityType.Index && (market == Market.USA || market == Market.EUREX || market == Market.OSE || market == Market.HKFE || market == Market.KRX)) ||
                 (securityType == SecurityType.FutureOption) ||
                 (securityType == SecurityType.Future) ||
                 (securityType == SecurityType.Cfd && market == Market.InteractiveBrokers);

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -203,7 +203,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             { Market.ICE, "NYBOT" },
             { Market.CFE, "CFE" },
             { Market.NYSELIFFE, "NYSELIFFE" },
-            { Market.EUREX, "EUREX" }
+            { Market.EUREX, "EUREX" },
+            { Market.KRX, "KSE" }
         };
 
         private static readonly SymbolPropertiesDatabase _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
@@ -4315,7 +4316,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             // our subscriptions are removed without any sort of notice.
             return
                 (securityType == SecurityType.Equity && market == Market.USA) ||
-                (securityType == SecurityType.Forex && market == Market.Oanda) ||
+                (securityType == SecurityType.Forex && (market == Market.Oanda || market == Market.InteractiveBrokers)) ||
                 (securityType == SecurityType.Option && market == Market.USA) ||
                 (securityType == SecurityType.IndexOption && market == Market.USA) ||
                 (securityType == SecurityType.Index && (market == Market.USA || market == Market.EUREX || market == Market.OSE || market == Market.HKFE)) ||


### PR DESCRIPTION
### Description

Adds Interactive Brokers support for the **KOSPI 200 Index Futures (`KM`)** on the Korea Exchange (`Market.KRX`), the brokerage counterpart to QuantConnect/Lean#9585 (which defines `Market.KRX` and `Futures.Indices.Kospi200`).

- **Route KM/KRX futures to IB's `KSE` exchange** — add `{ Market.KRX, "KSE" }` to `_futuresExchanges` so `GetSymbolExchange` returns the exchange IB expects instead of the raw `"krx"` market string.
- **Map the ticker** — IB's symbol for the contract is `K200` while LEAN's root is `KM`, so add `"K200": "KM"` to `IB-symbol-map.json`.
- **Value KRW positions in USD** — KOSPI 200 is KRW-denominated, and KRW has no tradeable pair in LEAN's default markets, so a USD account cannot value a KM position. IB provides `USD.KRW` as spot FX (`CASH … IDEALPRO`), so allow `Forex` subscriptions on `Market.InteractiveBrokers` in `CanSubscribe`, which lets LEAN derive the KRW→USD conversion rate from a live IB feed.
  - Companion **Lean** data changes (separate PR, alongside #9585): a `interactivebrokers,USDKRW,forex,USD/KRW,KRW,1,0.01,1` row in `symbol-properties-database.csv` (IB-confirmed `MinTick = 0.01`) and a `Forex-interactivebrokers-[*]` entry in `market-hours-database.json`.

Contract multiplier (KRW 250,000), tick (0.05), currency (KRW), quarterly cycle, and the 2nd-Thursday last-trading-day rule come from #9585's symbol-properties / expiry function — the brokerage only supplies the symbol/exchange routing.

### ⚠️ Draft — depends on QuantConnect/Lean#9585

This depends on #9585 being merged and a new `QuantConnect.Lean.Engine` package published (which provides `Market.KRX` and `Futures.Indices.Kospi200`). Kept as a draft until then.

### How this was validated (live, IB paper account)

Because this is a live-only integration (`GetContractDetails`/`GetHistory` against IB), it was validated by running the LEAN launcher against an IB paper account with the following driver algorithm and inspecting the logs.

<details>
<summary><code>KospiPriceLogger.py</code></summary>

```python
# Adds individual KOSPI 200 future contracts directly and logs their prices/history.
# Confirms the LEAN symbol "KM" on Market.KRX resolves to IB's "K200" contract on the
# "KSE" exchange, and that KRW positions can be valued in USD via IB's USD/KRW spot feed.

from AlgorithmImports import *
from QuantConnect.Securities.Future import FuturesExpiryFunctions
from datetime import datetime


class KospiPriceLogger(QCAlgorithm):
    def initialize(self):
        self.set_cash(100000)

        canonical = Symbol.create("KM", SecurityType.FUTURE, Market.KRX)
        expiry_fn = FuturesExpiryFunctions.futures_expiry_function(canonical)

        self._contracts = []
        # KOSPI 200 futures list on the quarterly Mar/Jun/Sep/Dec cycle.
        months = [datetime(y, m, 1) for y in (self.time.year, self.time.year + 1) for m in (3, 6, 9, 12)]
        for contract_month in sorted(months):
            expiry = expiry_fn(contract_month)
            if expiry <= self.time:
                continue  # already expired
            symbol = Symbol.create_future("KM", Market.KRX, expiry)
            self.add_future_contract(symbol, Resolution.MINUTE, extended_market_hours=True)
            self._contracts.append(symbol)
            self.log(f"Added KM contract {symbol.value} expiry={expiry.strftime('%Y-%m-%d')}")
            if len(self._contracts) >= 3:
                break

        # KRW->USD conversion via IB's USD/KRW spot (CASH … IDEALPRO) feed.
        self._usdkrw = self.add_forex("USDKRW", Resolution.MINUTE, Market.INTERACTIVE_BROKERS).symbol
        fx = list(self.history[QuoteBar](self._usdkrw, 5, Resolution.DAILY))
        self.log(f"USDKRW history: {len(fx)} bars" + (f"  last bid/ask={fx[-1].bid.close}/{fx[-1].ask.close}" if fx else " (none)"))

        # Historical data per contract (works even when the Seoul session is closed).
        for symbol in self._contracts:
            for resolution in (Resolution.DAILY, Resolution.MINUTE):
                bars = list(self.history[TradeBar](symbol, 10, resolution))
                self.log(f"HISTORY {symbol.value} {resolution}: {len(bars)} bars")
                if bars:
                    first, last = bars[0], bars[-1]
                    self.log(f"  first {first.end_time} O={first.open} C={first.close}  "
                             f"last {last.end_time} O={last.open} C={last.close} V={last.volume}")

    def on_data(self, slice: Slice):
        for symbol, bar in slice.bars.items():
            self.log(f"BAR  {symbol.value} {bar.end_time} O={bar.open} H={bar.high} "
                     f"L={bar.low} C={bar.close} V={bar.volume}")
```
</details>

**Output** — LEAN's `KM`/`Market.KRX` contracts resolve to IB `FUT K200 KRW KSE`, history returns real KOSPI 200 prices, and the USD/KRW rate is available so the KRW cash converts (the `No tradeable pair found for currency KRW` warning is gone):

```text
Added KM contract KM10U26 expiry=2026-09-10
Added KM contract KM10Z26 expiry=2026-12-10
Added KM contract KM11H27 expiry=2027-03-11

Subscribe Processed: KM10U26 (FUT K200 KRW KSE  20260910 0 )
Subscribe Processed: KM10Z26 (FUT K200 KRW KSE  20261210 0 )
Subscribe Processed: KM11H27 (FUT K200 KRW KSE  20270311 0 )

USDKRW history: 6 bars  last bid/ask=1528.939/1531.931      # CASH USD KRW IDEALPRO

HISTORY KM10U26 Daily: 10 bars
  first 2026-06-24 15:45:00 O=1339.35 C=1381.85  last 2026-07-07 15:45:00 O=1304.45 C=1245.75 V=172897
HISTORY KM10U26 Minute: 10 bars
HISTORY KM10Z26 Daily: 10 bars
HISTORY KM11H27 Daily: 10 bars
```

### Types of changes
- [X] New feature (non-breaking change which adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
