### PR TITLE
Bump IBAutomater to 2.0.90 and surface order confirmation messages

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -73,6 +73,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private const string BrokerageName = "Interactive Brokers Brokerage";
 
         /// <summary>
+        /// Prefix of the IBAutomater log line emitted when an order confirmation/warning
+        /// window is auto-accepted. The text after the prefix is the message shown to the user.
+        /// </summary>
+        private const string OrderConfirmationWindowMarker = "Order confirmation window: ";
+
+        /// <summary>
         /// During market open there can be some extra delay and resource constraint so let's be generous
         /// </summary>
         private static readonly TimeSpan _responseTimeout = TimeSpan.FromSeconds(Config.GetInt("ib-response-timeout", 60 * 5));
@@ -5198,7 +5204,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 var resultHandler = Composer.Instance.GetPart<IResultHandler>();
                 resultHandler?.DebugMessage("Logging into account. Check phone for two-factor authentication verification...");
             }
-            else if (e.Data.Contains("2FA maximum attempts reached", StringComparison.InvariantCultureIgnoreCase) || 
+            else if (e.Data.Contains("2FA maximum attempts reached", StringComparison.InvariantCultureIgnoreCase) ||
                      e.Data.Contains("IB Automater initialization timeout", StringComparison.InvariantCultureIgnoreCase))
             {
                 Task.Factory.StartNew(() =>
@@ -5208,6 +5214,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     OnMessage(BrokerageMessageEvent.Disconnected(message));
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.ActionRequired, "2FAAuthRequired", message));
                 });
+            }
+            else if (e.Data.Contains(OrderConfirmationWindowMarker, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // IBAutomater auto-accepted an order confirmation/warning window, let the user know
+                var index = e.Data.IndexOf(OrderConfirmationWindowMarker, StringComparison.InvariantCultureIgnoreCase);
+                var message = e.Data.Substring(index + OrderConfirmationWindowMarker.Length).Trim();
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "OrderConfirmationWindow", message));
             }
 
             Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterOutputDataReceived(): {e.Data}");

--- a/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
+++ b/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
 	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
 	  <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
-	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.89">
+	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.90">
 		  <!--
 		  Content files of dependencies are excluded by default.
 		  This allows content files to be available in project where nuget will be consumed.


### PR DESCRIPTION
- Bump IBAutomater version to 2.0.90:
  - Handles the new IB Gateway order confirmation windows ("Market Order Confirmation", "Cash Quantity Order Warning") — detects them by their "Accept and Continue" button, selects "Don't display this message again." and accepts
  - Improves the "Financial Advisor Warning" window handling — the dominant root cause of #93 (selects the gating check box, prefers the redesigned confirmation buttons, and verifies the window actually closed)
- Surface the order confirmation/warning message to the user: when IBAutomater auto-accepts one of these windows it logs the dialog message, which the brokerage now forwards as a Warning `BrokerageMessage`
- See related https://github.com/QuantConnect/IBAutomater/pull/104

Related to #93 (complements the brokerage-side mitigation in #240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
