### PR TITLE
Bump IBAutomater to 2.0.91 for FA warning window diagnostics

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
+++ b/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
 	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
 	  <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
-	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.90">
+	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.91">
 		  <!--
 		  Content files of dependencies are excluded by default.
 		  This allows content files to be available in project where nuget will be consumed.


### PR DESCRIPTION
Brings in QuantConnect/IBAutomater#106 (diagnostics-only, no behavior change):

- The "Financial Advisor Warning" window contents (message text, every button and check box with its enabled/selected state) are now logged before the window is handled, so the next occurrence of #93 — they recur daily — captures exactly what the dialog says and which control transmits the order
- An error is logged when the "Yes" button is disabled (`doClick()` on a disabled button is a silent no-op)
- The unknown-window diagnostic dump no longer depends on the window name

Once the evidence is captured, a follow-up IBAutomater PR will implement the actual fix for the lost FA group orders.

Note: NuGet package 2.0.91 is published when QuantConnect/IBAutomater#106 is merged — this PR will not build until then.

Related to #93 (complements the brokerage-side mitigation in #240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)