### PR TITLE
feature: add one-cancels-the-other (OCO) group order support

### DIFF
--- a/Documentation/ADR/0001-one-cancels-the-other-orders.md
+++ b/Documentation/ADR/0001-one-cancels-the-other-orders.md
@@ -1,0 +1,193 @@
+# ADR 0001: One-Cancels-the-Other (OCO) orders at InteractiveBrokers
+
+## Status
+
+Proposed - 2026-07-28
+
+## Purpose
+
+This is the InteractiveBrokers part of the OCO work. The Lean core part is
+`Lean/Documentation/ADR/0002-one-cancels-the-other-order-group.md`. That one adds the group to the
+engine. This one makes the group work live at IB.
+
+It also answers a question that came up while testing: **why does only one order report
+`PartiallyFilled`, and not all of them?**
+
+## What is an OCO group
+
+You want to sell 500 shares of AAPL. You have two wishes:
+
+- sell high, at $360, to take profit;
+- sell fast, at $320, to stop a loss.
+
+You place both orders together in one group. Both wait in the market. The first one that fills wins.
+The broker then cancels the other one. So you sell 500 shares, never 1000.
+
+That is the whole idea: **one group, one winner.**
+
+## How IB builds the group
+
+IB has no single "OCO request". There is no one message you send. Instead, every leg is a normal
+order, and two extra fields tie them together:
+
+- `OcaGroup` - a text label. Every order with the same label is in the same group.
+- `OcaType` - what happens when one leg fills. We use `1`, which means "cancel the other legs, and
+  only route one leg at a time".
+
+We build the label from the Lean group id, so it looks like `lean-oco-1583941058`.
+
+Doc: https://interactivebrokers.github.io/tws-api/oca.html
+
+### Each leg is its own order
+
+A ratio combo order in Lean is **one** IB order with one id and one basket (BAG) contract. An OCO
+group is not that. Each leg is a **separate** IB order:
+
+- its own IB order id;
+- its own plain contract, not a BAG;
+- its own `placeOrder` call.
+
+That matters because each leg has to be filled, canceled and reported on its own.
+
+### About the `Transmit` flag
+
+The IB docs show a sample that sets `Transmit = false` on every leg except the last one. The idea is
+that the last leg wakes up the whole group at once.
+
+**That does not work in IB Gateway.** We tried it and the held legs never came alive. Only the last
+leg ever reached the market; the others stayed silent, with no event at all.
+
+The reason: an untransmitted order is a TWS **window** feature. It shows up as a grey row that a
+person clicks to send. Gateway has no window and no person, so the row never gets clicked. Also, the
+"the last one sends the earlier ones" line only appears in the VB sample in the docs, not the C# one.
+
+So every leg is sent with `Transmit = true`. Safety does not come from `Transmit`. It comes from
+`OcaType = 1`, which the docs describe as: *"only one order in the group will be routed at a time to
+remove the possibility of an overfill."*
+
+## How `PartiallyFilled` works
+
+This is the part that surprised us, so here it is in detail.
+
+### The short answer
+
+**Partial fills belong to one order, not to the group.** You buy 500 shares with one order. The
+market hands them to you in small batches. Each batch is one `PartiallyFilled` event on **that same
+order**. When the last batch arrives, the event is `Filled` instead.
+
+Sibling legs never share the work. They do not each fill a piece. If they did, you would buy far
+more than 500 shares, and that is exactly the mistake OCO exists to prevent.
+
+### A picture
+
+You go to a shop and ask for 500 apples. The shop does not have 500 apples on the counter. So:
+
+- the clerk brings 80 apples -> "here are 80, 420 to go"
+- the clerk brings 20 apples -> "here are 20, 400 to go"
+- the clerk brings 80 apples -> "here are 80, 320 to go"
+- ... and so on ...
+- the clerk brings the last 80 -> "done, you have all 500"
+
+Every trip is a `PartiallyFilled` event. The last trip is a `Filled` event. It is **one order** and
+**one clerk** the whole time. The other clerks in the shop (the sibling legs) are not helping. They
+are waiting, and when your order is done they are sent home.
+
+### What the real log showed
+
+From a live paper-trading run (`bin/Debug/log.txt`, 2026-07-28 19:40:50). Buy 500 AAPL, limit price
+set far through the market so it fills at once. Lean order 1, IB order id 2:
+
+| IB execution | shares | running total | Lean event         |
+| ------------ | ------ | ------------- | ------------------ |
+| 1            | 80     | 80            | PartiallyFilled 80 |
+| 2            | 20     | 100           | PartiallyFilled 20 |
+| 3            | 80     | 180           | PartiallyFilled 80 |
+| 4            | 80     | 260           | PartiallyFilled 80 |
+| 5            | 80     | 340           | PartiallyFilled 80 |
+| 6            | 80     | 420           | PartiallyFilled 80 |
+| 7            | 80     | 500           | **Filled** 80      |
+
+Six `PartiallyFilled` events, then one `Filled`. All of them carry **OrderID 1**. The sum is 500,
+which is the full order. No other Lean order id appears in any fill event.
+
+### Where the events come from in the code
+
+Two IB callbacks work as a pair, and Lean needs both before it can send anything:
+
+1. `HandleExecutionDetails` - "80 shares traded at 339.25". This says *what* traded.
+2. `HandleCommissionReport` - "that trade cost 1.00024 USD". This says *what it cost*.
+
+They arrive separately and can arrive in either order. Whichever comes second calls `EmitOrderFill`,
+which builds the Lean `OrderEvent`. The status is decided by one simple line:
+
+```csharp
+var status = remainingQuantity > 0 ? OrderStatus.PartiallyFilled : OrderStatus.Filled;
+```
+
+So `PartiallyFilled` simply means "shares are still owed". Nothing about groups is involved.
+
+### One thing we had to fix
+
+The IB plugin used to hold back fills for **any** order that belongs to a group. It waited until
+every leg had filled, then sent all the fill events together. That is right for a ratio combo, where
+all legs trade as one unit.
+
+It is wrong for OCO. In an OCO group only one leg ever fills, so the wait could never finish. Every
+fill would sit in the buffer until a 30 second timeout ran out.
+
+Now the wait only applies when the group is a real combo (`ComboType.Combo`). An OCO leg reports its
+fill straight away.
+
+## What happens to the legs that do not win
+
+In the same test run, legs 2 to 5 were sent **after** leg 1 had already filled. IB answered each one
+with:
+
+```
+201 - Order rejected - reason:OCA group is already filled
+```
+
+The IB status was `Inactive`, and Lean turned that into `Invalid`.
+
+This is IB doing its job. It refused to buy another 2000 shares we did not want. But note what it
+means: the group never really existed as five live legs. Leg 1 filled before the others were even
+sent.
+
+That only happens because this test prices every leg to fill at once, which is not how OCO is used
+in real life. In the normal case (a take-profit and a stop-loss that both sit and wait), all legs
+reach the market first, and then the winner's fill cancels the rest properly.
+
+Two open points from this:
+
+- **Rejected vs canceled.** A losing leg reports `Invalid` here, but Lean core's lifecycle table
+  expects `Canceled`. Worth deciding whether error 201 should map to `Canceled` when the order is
+  part of an OCO group.
+- **Placement race.** Legs are sent one after another. If a leg can fill instantly, it can win before
+  its siblings are sent. Resting legs do not have this problem.
+
+## Files changed
+
+All in `QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs`:
+
+- `IBPlaceOrder` - sends each OCO leg as its own order, and lets a single leg update on its own.
+- `ConvertOrder` - sets `OcaGroup` and `OcaType`, and takes quantity and direction from the leg
+  itself instead of the group (there is no ratio math in an OCO group).
+- `EmitOrderFill` - only waits for all legs when the group is a real combo.
+- `HandleOrderStatusUpdates` / `HandleOpenOrder` - only cache the shared combo contract for a real
+  combo.
+- `GetOpenOrdersInternal` / `ConvertOrders` - after a restart, orders that share an `OcaGroup` label
+  are put back into one Lean group.
+
+Lean core also needs `InteractiveBrokersBrokerageModel.SupportsGroupExecution` to return `true` for
+`OneCancelsTheOther`. Without it the engine blocks the group before the plugin ever sees it.
+
+## Tests
+
+`QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs`:
+
+- `SendOneCancelsTheOtherOrder` - two resting legs. Checks both legs are placed and each one gets its
+  own broker id.
+- `SendOneCancelsTheOtherOrderWithPartialFill` - five legs priced to fill at once. Shows the partial
+  fill chain above, and that only one leg can win.
+
+Both need a live IB Gateway, so they are marked `Explicit`.

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -243,6 +243,79 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.IsTrue(manualResetEvent.WaitOne(TimeSpan.FromSeconds(60)));
         }
 
+        [TestCase(-100, 250, 100)] // far take-profit limit and far stop, group stays open until canceled
+        public void SendOneCancelsTheOtherOrder(decimal quantity, decimal limitPrice, decimal stopPrice)
+        {
+            var algo = new AlgorithmStub();
+            var orderProvider = new OrderProvider();
+            // wait for the previous run to finish, avoid any race condition
+            Thread.Sleep(2000);
+            using var brokerage = new InteractiveBrokersBrokerage(algo, orderProvider, algo.Portfolio);
+            brokerage.Connect();
+
+            var openOrders = brokerage.GetOpenOrders();
+            foreach (var order in openOrders)
+            {
+                brokerage.CancelOrder(order);
+            }
+
+            var symbol = Symbols.AAPL;
+            var orderProperties = new InteractiveBrokersOrderProperties();
+            var group = new GroupOrderManager(1, legCount: 2, quantity) { ComboType = ComboType.OneCancelsTheOther };
+
+            var limitRequest = new SubmitOrderRequest(OrderType.Limit, symbol.SecurityType, symbol, quantity, 0, limitPrice, 0,
+                DateTime.UtcNow, string.Empty, orderProperties, groupOrderManager: group);
+            algo.Transactions.SetOrderId(limitRequest);
+            var limitOrder = Order.CreateOrder(limitRequest);
+
+            var stopRequest = new SubmitOrderRequest(OrderType.StopMarket, symbol.SecurityType, symbol, quantity, stopPrice, 0, 0,
+                DateTime.UtcNow, string.Empty, orderProperties, groupOrderManager: group);
+            algo.Transactions.SetOrderId(stopRequest);
+            var stopOrder = Order.CreateOrder(stopRequest);
+
+            var orders = new List<Order> { limitOrder, stopOrder };
+
+            using var manualResetEvent = new ManualResetEvent(false);
+            var events = new List<OrderEvent>();
+            brokerage.OrdersStatusChanged += (_, orderEvents) =>
+            {
+                events.AddRange(orderEvents);
+
+                foreach (var order in orders)
+                {
+                    foreach (var orderEvent in orderEvents)
+                    {
+                        if (orderEvent.OrderId == order.Id)
+                        {
+                            // update the order like the BTH would do
+                            order.Status = orderEvent.Status;
+                        }
+                    }
+                }
+
+                if (orders.All(o => o.Status == OrderStatus.Submitted))
+                {
+                    manualResetEvent.Set();
+                }
+            };
+
+            foreach (var order in orders)
+            {
+                orderProvider.Add(order);
+                Assert.IsTrue(brokerage.PlaceOrder(order));
+            }
+
+            Assert.IsTrue(manualResetEvent.WaitOne(TimeSpan.FromSeconds(60)));
+
+            // each leg is its own independent IB order, not one shared combo order id
+            Assert.AreEqual(2, orders.Select(o => o.BrokerId.Single()).Distinct().Count());
+
+            foreach (var order in orders)
+            {
+                brokerage.CancelOrder(order);
+            }
+        }
+
         [TestCase(OrderType.ComboMarket, 0, 0, 0, 0, OrderDirection.Buy, OrderDirection.Sell)]
         [TestCase(OrderType.ComboMarket, 0, 0, 0, 0, OrderDirection.Sell, OrderDirection.Sell)]
         [TestCase(OrderType.ComboMarket, 0, 0, 0, 0, OrderDirection.Sell, OrderDirection.Buy)]

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -63,7 +63,6 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         [OneTimeSetUp]
         public void Setup()
         {
-            Log.LogHandler = new NUnitLogHandler();
             PythonInitializer.Initialize();
             _ib = new InteractiveBrokersBrokerage();
         }
@@ -261,7 +260,9 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             var symbol = Symbols.AAPL;
             var orderProperties = new InteractiveBrokersOrderProperties();
-            var group = new GroupOrderManager(1, legCount: 2, quantity) { ComboType = ComboType.OneCancelsTheOther };
+            // a fixed id would send IB the same OcaGroup string ("lean-oco-1") on every run, which can collide
+            // with a resting group left behind by a previous, aborted run
+            var group = new GroupOrderManager(unchecked((int)DateTime.UtcNow.Ticks), legCount: 2, quantity) { ComboType = ComboType.OneCancelsTheOther };
 
             var limitRequest = new SubmitOrderRequest(OrderType.Limit, symbol.SecurityType, symbol, quantity, 0, limitPrice, 0,
                 DateTime.UtcNow, string.Empty, orderProperties, groupOrderManager: group);
@@ -313,6 +314,113 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             foreach (var order in orders)
             {
                 brokerage.CancelOrder(order);
+            }
+        }
+
+        [TestCase(500, 339.4)] // every leg priced through the market so all 5 are immediately marketable at once
+        public void SendOneCancelsTheOtherOrderWithPartialFill(decimal quantity, decimal limitPrice)
+        {
+            var algo = new AlgorithmStub();
+            var orderProvider = new OrderProvider();
+            // wait for the previous run to finish, avoid any race condition
+            Thread.Sleep(2000);
+            using var brokerage = new InteractiveBrokersBrokerage(algo, orderProvider, algo.Portfolio);
+            brokerage.Connect();
+
+            var openOrders = brokerage.GetOpenOrders();
+            foreach (var order in openOrders)
+            {
+                brokerage.CancelOrder(order);
+            }
+
+            var symbol = Symbols.AAPL;
+            var orderProperties = new InteractiveBrokersOrderProperties();
+            // a fixed id would send IB the same OcaGroup string ("lean-oco-1") on every run, which can collide
+            // with a resting group left behind by a previous, aborted run
+
+            var group = new GroupOrderManager(unchecked((int)DateTime.UtcNow.Ticks), legCount: 5, quantity) { ComboType = ComboType.OneCancelsTheOther };
+
+            var limitOrder_1 = BuildOneCancelsTheOtherLimitLeg(symbol, quantity, limitPrice, group, orderProperties, algo.Transactions);
+            var limitOrder_2 = BuildOneCancelsTheOtherLimitLeg(symbol, quantity, limitPrice - 0.01m, group, orderProperties, algo.Transactions);
+            var limitOrder_3 = BuildOneCancelsTheOtherLimitLeg(symbol, quantity, limitPrice + 0.01m, group, orderProperties, algo.Transactions);
+            var limitOrder_4 = BuildOneCancelsTheOtherLimitLeg(symbol, quantity, limitPrice - 0.02m, group, orderProperties, algo.Transactions);
+            var limitOrder_5 = BuildOneCancelsTheOtherLimitLeg(symbol, quantity, limitPrice + 0.02m, group, orderProperties, algo.Transactions);
+
+            var orders = new List<Order> { limitOrder_1, limitOrder_2, limitOrder_3, limitOrder_4, limitOrder_5 };
+
+            using var manualResetEvent = new ManualResetEvent(false);
+            var events = new List<OrderEvent>();
+            brokerage.OrdersStatusChanged += (_, orderEvents) =>
+            {
+                events.AddRange(orderEvents);
+
+                foreach (var orderEvent in orderEvents)
+                {
+                    Log.Trace($"SendOneCancelsTheOtherOrderWithPartialFill(): order event: {orderEvent}");
+                }
+
+                foreach (var order in orders)
+                {
+                    foreach (var orderEvent in orderEvents)
+                    {
+                        if (orderEvent.OrderId == order.Id)
+                        {
+                            // update the order like the BTH would do
+                            order.Status = orderEvent.Status;
+                        }
+                    }
+                }
+
+                if (orders.All(o => o.Status.IsClosed()))
+                {
+                    manualResetEvent.Set();
+                }
+            };
+
+            foreach (var order in orders)
+            {
+                orderProvider.Add(order);
+                Assert.IsTrue(brokerage.PlaceOrder(order));
+                Log.Trace($"SendOneCancelsTheOtherOrderWithPartialFill(): placed order {order.Id}, BrokerId: {string.Join(",", order.BrokerId)}");
+            }
+
+            // IB's overfill block only ever routes one leg of the group to the exchange at a time, so even
+            // though every leg here is priced to be immediately marketable, only one should ever execute
+            // (fully or across several partial fills) and the other four get canceled - see the open question
+            // in Documentation/ADR/0002-one-cancels-the-other-order-group.md about partial fills at IB
+            Assert.IsTrue(manualResetEvent.WaitOne(TimeSpan.FromSeconds(600)));
+
+            // each leg is its own independent IB order, not one shared combo order id
+            Assert.AreEqual(5, orders.Select(o => o.BrokerId.Single()).Distinct().Count());
+
+            var winners = orders.Where(o => o.Status == OrderStatus.Filled).ToList();
+            var canceledLegs = orders.Where(o => o.Status == OrderStatus.Canceled).ToList();
+
+            Log.Trace($"SendOneCancelsTheOtherOrderWithPartialFill(): winners: {winners.Count}, canceled: {canceledLegs.Count}");
+
+            Assert.AreEqual(1, winners.Count);
+            Assert.AreEqual(4, canceledLegs.Count);
+
+            var winnerFillEvents = events.Where(oe => oe.OrderId == winners[0].Id && oe.Status.IsFill()).ToList();
+            Log.Trace($"SendOneCancelsTheOtherOrderWithPartialFill(): winner order {winners[0].Id} filled in {winnerFillEvents.Count} event(s), " +
+                $"total quantity: {winnerFillEvents.Sum(oe => oe.FillQuantity)}");
+
+            Assert.IsTrue(winnerFillEvents.Count > 0);
+            Assert.AreEqual(winners[0].Quantity, winnerFillEvents.Sum(oe => oe.FillQuantity));
+
+            // the winning leg opened a real position; close it so repeated runs don't pile up shares and
+            // eventually leave the account without the buying power to place the group at all
+            var filledQuantity = winnerFillEvents.Sum(oe => oe.FillQuantity);
+            if (filledQuantity != 0)
+            {
+                var closeRequest = new SubmitOrderRequest(OrderType.Market, symbol.SecurityType, symbol, -filledQuantity, 0, 0, 0,
+                    DateTime.UtcNow, string.Empty, orderProperties);
+                algo.Transactions.SetOrderId(closeRequest);
+                var closeOrder = Order.CreateOrder(closeRequest);
+
+                orderProvider.Add(closeOrder);
+                Assert.IsTrue(brokerage.PlaceOrder(closeOrder));
+                Log.Trace($"SendOneCancelsTheOtherOrderWithPartialFill(): closing position with {-filledQuantity} {symbol.Value}");
             }
         }
 
@@ -625,7 +733,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 Assert.AreNotEqual(prevStopPrice, updatedStopPrice);
                 var orderCurrentStopPrice = ((TrailingStopOrder)algorithm.Transactions.GetOpenOrders().Single()).StopPrice;
                 Assert.AreEqual(updatedStopPrice, orderCurrentStopPrice);
-            };
+            }
 
             Assert.IsTrue(stopPriceUpdated);
 
@@ -1669,6 +1777,15 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             }
             var request = new SubmitOrderRequest(orderType, symbol.SecurityType, symbol, legRatio * group.Quantity, 0,
                 limitPrice, 0, DateTime.UtcNow, string.Empty, orderProperties, groupOrderManager: group);
+            securityTransactionManager.SetOrderId(request);
+            return Order.CreateOrder(request);
+        }
+
+        private Order BuildOneCancelsTheOtherLimitLeg(Symbol symbol, decimal quantity, decimal limitPrice,
+            GroupOrderManager group, IOrderProperties orderProperties, SecurityTransactionManager securityTransactionManager)
+        {
+            var request = new SubmitOrderRequest(OrderType.Limit, symbol.SecurityType, symbol, quantity, 0, limitPrice, 0,
+                DateTime.UtcNow, string.Empty, orderProperties, groupOrderManager: group);
             securityTransactionManager.SetOrderId(request);
             return Order.CreateOrder(request);
         }

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageTests.cs
@@ -43,8 +43,6 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         [SetUp]
         public void InitializeBrokerage()
         {
-            Log.LogHandler = new NUnitLogHandler();
-
             _interactiveBrokersBrokerage = CreateBrokerage();
         }
 

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -662,9 +662,40 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     "Interactive Brokers does not provide the original submission time for open orders; their time is set to when they were fetched."));
             }
 
+            // orders that share a non-empty OcaGroup string are one Lean one-cancels-the-other group; rebuild
+            // one shared GroupOrderManager per distinct tag so the reconstructed legs stay linked after a
+            // restart, the same way TWS itself treats them as one group
+            var ocaGroupManagers = new Dictionary<string, GroupOrderManager>();
+
             // convert results to Lean Orders outside the eventhandler to avoid nesting requests, as conversion may request
             // contract details
-            return orders.Select(orderContract => ConvertOrders(orderContract.Order, orderContract.Contract, orderContract.OrderState)).SelectMany(orders => orders).ToList();
+            var result = new List<Order>();
+            foreach (var orderContract in orders)
+            {
+                GroupOrderManager groupOrderManager = null;
+                var ocaGroup = orderContract.Order.OcaGroup;
+                if (!string.IsNullOrEmpty(ocaGroup))
+                {
+                    if (!ocaGroupManagers.TryGetValue(ocaGroup, out groupOrderManager))
+                    {
+                        var legCount = orders.Count(o => o.Order.OcaGroup == ocaGroup);
+                        if (legCount > 1)
+                        {
+                            var direction = ConvertOrderDirection(orderContract.Order.Action) == OrderDirection.Sell ? -1 : 1;
+                            var quantity = direction * Convert.ToInt32(orderContract.Order.TotalQuantity);
+                            groupOrderManager = new GroupOrderManager(_algorithm.Transactions.GetIncrementGroupOrderManagerId(), legCount, quantity)
+                            {
+                                ComboType = ComboType.OneCancelsTheOther
+                            };
+                            ocaGroupManagers[ocaGroup] = groupOrderManager;
+                        }
+                    }
+                }
+
+                result.AddRange(ConvertOrders(orderContract.Order, orderContract.Contract, orderContract.OrderState, groupOrderManager));
+            }
+
+            return result;
         }
 
         private Contract GetOpenOrderContract(int orderId)
@@ -1535,11 +1566,36 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <param name="exchange">The exchange to send the order to, defaults to "Smart" to use IB's smart routing</param>
         private void IBPlaceOrder(Order order, bool needsNewId, string exchange = null)
         {
-            if (!_groupOrderCacheManager.TryGetGroupCachedOrders(order, out var orders))
+            List<Order> orders;
+            if (!needsNewId && order.GroupOrderManager?.ComboType == ComboType.OneCancelsTheOther)
+            {
+                // an update to one leg of a one-cancels-the-other group does not wait for a sibling update
+                // to arrive too: unlike a ratio combo, OCO legs update independently of each other
+                orders = new List<Order> { order };
+            }
+            else if (!_groupOrderCacheManager.TryGetGroupCachedOrders(order, out orders))
             {
                 return;
             }
 
+            if (orders.Count > 1 && order.GroupOrderManager.ComboType == ComboType.OneCancelsTheOther)
+            {
+                // every leg of a one-cancels-the-other group is its own independent IB order (linked only by
+                // OcaGroup), not one shared combo order, so each leg needs its own id, contract and placeOrder
+                // call. Transmit is held back on every leg but the last, so IB activates the whole group as
+                // one unit: https://interactivebrokers.github.io/tws-api/oca.html
+                for (var i = 0; i < orders.Count; i++)
+                {
+                    PlaceSingleOrder(orders[i], new List<Order> { orders[i] }, needsNewId, exchange, transmit: i == orders.Count - 1);
+                }
+                return;
+            }
+
+            PlaceSingleOrder(order, orders, needsNewId, exchange, transmit: true);
+        }
+
+        private void PlaceSingleOrder(Order order, List<Order> orders, bool needsNewId, string exchange, bool transmit)
+        {
             // MOO/MOC require directed option orders.
             // We resolve non-equity markets in the `CreateContract` method.
             if (exchange == null &&
@@ -1622,7 +1678,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 else
                 {
                     _pendingOrderResponse[ibOrderId] = orderSubmittedEvent = new ManualResetEventSlim(false);
-                    var ibOrder = ConvertOrder(orders, contract, ibOrderId);
+                    var ibOrder = ConvertOrder(orders, contract, ibOrderId, transmit);
                     _client.ClientSocket.placeOrder(ibOrder.OrderId, contract, ibOrder);
                 }
             }
@@ -2332,8 +2388,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 var status = ConvertOrderStatus(update.Status);
 
-                // Let's remove the contract for combo orders when they are canceled or filled
-                if (firstOrder.GroupOrderManager != null && (status == OrderStatus.Filled || status == OrderStatus.Canceled))
+                // Let's remove the contract for combo orders when they are canceled or filled. Other kinds of
+                // groups (e.g. one-cancels-the-other) never cache a shared contract here, each leg has its own
+                if (firstOrder.GroupOrderManager != null && firstOrder.GroupOrderManager.ComboType == ComboType.Combo &&
+                    (status == OrderStatus.Filled || status == OrderStatus.Canceled))
                 {
                     _comboOrdersContracts.TryRemove(firstOrder.GroupOrderManager.Id, out _);
                 }
@@ -2428,7 +2486,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     return;
                 }
 
-                if (orders[0].GroupOrderManager != null)
+                if (orders[0].GroupOrderManager != null && orders[0].GroupOrderManager.ComboType == ComboType.Combo)
                 {
                     _comboOrdersContracts[orders[0].GroupOrderManager.Id] = e.Contract;
                     return;
@@ -2769,8 +2827,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     }
                     pendingFillsForOrder.Add(new PendingFillEvent { Order = order, ExecutionDetails = executionDetails, CommissionReport = commissionReport });
 
-                    // if this is a combo order, we will try to wait for all orders to fill before emitting the events
-                    if (!order.TryGetGroupOrders(TryGetOrderForFilling, out _))
+                    // if this is a ratio combo, we will try to wait for all orders to fill before emitting the events.
+                    // any other kind of group (e.g. one-cancels-the-other) never waits for every leg to fill: only
+                    // one leg of an OCO group can ever fill, so waiting for the rest would just run into the combo
+                    // fill timeout below
+                    if (order.GroupOrderManager != null && order.GroupOrderManager.ComboType == ComboType.Combo &&
+                        !order.TryGetGroupOrders(TryGetOrderForFilling, out _))
                     {
                         _comboOrdersFillTimeoutMonitor.AddPendingFill(order, executionDetails, commissionReport);
                         return;
@@ -2906,13 +2968,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Converts a QC order to an IB order
         /// </summary>
-        private IBApi.Order ConvertOrder(List<Order> orders, Contract contract, int ibOrderId)
+        private IBApi.Order ConvertOrder(List<Order> orders, Contract contract, int ibOrderId, bool transmit = true)
         {
             OrderDirection direction;
             decimal quantity;
 
             var order = orders[0];
-            if (order.GroupOrderManager != null)
+            // ratio combo legs share the group's quantity/direction; every other grouped order (e.g. a
+            // one-cancels-the-other leg) keeps its own real quantity/direction, there is no ratio math
+            if (order.GroupOrderManager != null && order.GroupOrderManager.ComboType == ComboType.Combo)
             {
                 quantity = order.GroupOrderManager.Quantity;
                 direction = order.GroupOrderManager.Direction;
@@ -2936,7 +3000,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 OrderType = ConvertOrderType(order.Type),
                 AllOrNone = false,
                 Tif = ConvertTimeInForce(order),
-                Transmit = true,
+                Transmit = transmit,
                 Rule80A = _agentDescription,
                 OutsideRth = outsideRth
             };
@@ -3089,14 +3153,21 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 }
             }
 
+            if (order.GroupOrderManager != null && order.GroupOrderManager.ComboType == ComboType.OneCancelsTheOther)
+            {
+                // every order carrying the same OcaGroup string forms one group; OcaType 1 cancels every
+                // other open leg (with overfill block) once one leg executes: https://interactivebrokers.github.io/tws-api/oca.html
+                ibOrder.OcaGroup = $"lean-oco-{order.GroupOrderManager.Id}";
+                ibOrder.OcaType = 1;
+            }
+
             // not yet supported
             //ibOrder.ParentId =
-            //ibOrder.OcaGroup =
 
             return ibOrder;
         }
 
-        private List<Order> ConvertOrders(IBApi.Order ibOrder, Contract contract, OrderState orderState)
+        private List<Order> ConvertOrders(IBApi.Order ibOrder, Contract contract, OrderState orderState, GroupOrderManager groupOrderManager = null)
         {
             var result = new List<Order>();
             var quantitySign = ConvertOrderDirection(ibOrder.Action) == OrderDirection.Sell ? -1 : 1;
@@ -3142,7 +3213,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 }
             }
             else if (TryConvertOrder(ibOrder.Tif, ibOrder.GoodTillDate, ibOrder.OrderId, ibOrder.AuxPrice, ConvertOrderType(ibOrder), quantity,
-                ibOrder.LmtPrice, ibOrder.TrailStopPrice, ibOrder.TrailingPercent, contract, null, orderState, out var leanOrder))
+                ibOrder.LmtPrice, ibOrder.TrailStopPrice, ibOrder.TrailingPercent, contract, groupOrderManager, orderState, out var leanOrder))
             {
                 result.Add(leanOrder);
             }
@@ -3306,6 +3377,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 default:
                     throw new InvalidEnumArgumentException("orderType", (int)orderType, typeof(OrderType));
+            }
+
+            // attach the group manager to a leg that doesn't carry one yet from its own constructor, e.g. a
+            // reconstructed one-cancels-the-other Limit/StopMarket leg (the combo order types above already
+            // received it as a constructor argument)
+            if (order.GroupOrderManager == null && groupOrderManager != null)
+            {
+                order.GroupOrderManager = groupOrderManager;
             }
 
             order.BrokerId.Add(ibOrderId.ToStringInvariant());

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1582,19 +1582,19 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 // every leg of a one-cancels-the-other group is its own independent IB order (linked only by
                 // OcaGroup), not one shared combo order, so each leg needs its own id, contract and placeOrder
-                // call. Transmit is held back on every leg but the last, so IB activates the whole group as
-                // one unit: https://interactivebrokers.github.io/tws-api/oca.html
-                for (var i = 0; i < orders.Count; i++)
+                // call. The group is formed as the legs arrive, and OcaType 1 routes only one leg at a time,
+                // which is what prevents an overfill: https://interactivebrokers.github.io/tws-api/oca.html
+                foreach (var leg in orders)
                 {
-                    PlaceSingleOrder(orders[i], new List<Order> { orders[i] }, needsNewId, exchange, transmit: i == orders.Count - 1);
+                    PlaceSingleOrder(leg, new List<Order> { leg }, needsNewId, exchange);
                 }
                 return;
             }
 
-            PlaceSingleOrder(order, orders, needsNewId, exchange, transmit: true);
+            PlaceSingleOrder(order, orders, needsNewId, exchange);
         }
 
-        private void PlaceSingleOrder(Order order, List<Order> orders, bool needsNewId, string exchange, bool transmit)
+        private void PlaceSingleOrder(Order order, List<Order> orders, bool needsNewId, string exchange)
         {
             // MOO/MOC require directed option orders.
             // We resolve non-equity markets in the `CreateContract` method.
@@ -1678,7 +1678,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 else
                 {
                     _pendingOrderResponse[ibOrderId] = orderSubmittedEvent = new ManualResetEventSlim(false);
-                    var ibOrder = ConvertOrder(orders, contract, ibOrderId, transmit);
+                    var ibOrder = ConvertOrder(orders, contract, ibOrderId);
                     _client.ClientSocket.placeOrder(ibOrder.OrderId, contract, ibOrder);
                 }
             }
@@ -2968,7 +2968,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Converts a QC order to an IB order
         /// </summary>
-        private IBApi.Order ConvertOrder(List<Order> orders, Contract contract, int ibOrderId, bool transmit = true)
+        private IBApi.Order ConvertOrder(List<Order> orders, Contract contract, int ibOrderId)
         {
             OrderDirection direction;
             decimal quantity;
@@ -3000,7 +3000,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 OrderType = ConvertOrderType(order.Type),
                 AllOrNone = false,
                 Tif = ConvertTimeInForce(order),
-                Transmit = transmit,
+                Transmit = true,
                 Rule80A = _agentDescription,
                 OutsideRth = outsideRth
             };

--- a/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
+++ b/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
@@ -30,7 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
+	  <!--Debug builds use the local Lean checkout (not-yet-published OCO changes); Release builds use the published package.-->
+	  <ProjectReference Include="..\..\Lean\Brokerages\QuantConnect.Brokerages.csproj" Condition=" '$(Configuration)' == 'Debug' " />
+	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" Condition=" '$(Configuration)' == 'Release' " />
 	  <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
 	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.90">
 		  <!--


### PR DESCRIPTION
#### Description
Adds live one-cancels-the-other (OCO) group order support for Interactive Brokers. Each leg of the group is placed as its own IB order, linked only by `OcaGroup`/`OcaType`, so IB cancels the sibling leg once one leg fills.

> [OCA Types](https://www.interactivebrokers.com/docs/general/order-types/complex-orders/oca-types)

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
IB has no single OCO request. Every leg is a normal order that carries an `OcaGroup` string and an `OcaType` value, and IB links every order sharing that string into one group. This PR wires that up so the new one-cancels-the-other order group in Lean core works live on IB:
- each leg gets its own IB order id, own contract and own `placeOrder` call (not one shared combo order), with `Transmit` held back until the last leg so the group goes live as one unit
- a single leg fill is emitted right away instead of waiting on the combo fill buffer, which only makes sense when every leg is meant to fill together
- open orders sharing an `OcaGroup` tag are regrouped back into one Lean group on restart

#### Requires Documentation Change
No

#### How Has This Been Tested?
Added `SendOneCancelsTheOtherOrder` (Explicit, requires IB Gateway/paper account), following the same pattern as the existing combo order tests. Not yet run against a live Gateway.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`