### PR TITLE
Report and recover a connection lost to the gateway restart

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
@@ -1,0 +1,291 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.InteractiveBrokers;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Orders;
+using QuantConnect.Tests.Engine;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
+{
+    [TestFixture]
+    public class InteractiveBrokersBrokerageConnectionTests
+    {
+        private static readonly FieldInfo HeartBeatTimeLimitField =
+            typeof(InteractiveBrokersBrokerage).GetField("_heartBeatTimeLimit", BindingFlags.NonPublic | BindingFlags.Static);
+
+        private TimeSpan _originalHeartBeatTimeLimit;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // the heart beat is skipped after 23:00 local time because of the gateway daily restart, which would
+            // make the tests below assert nothing when they happen to run in that hour. Push the limit out so the
+            // wall clock stops deciding which branch is exercised.
+            _originalHeartBeatTimeLimit = (TimeSpan)HeartBeatTimeLimitField.GetValue(null);
+            HeartBeatTimeLimitField.SetValue(null, TimeSpan.FromDays(1));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HeartBeatTimeLimitField.SetValue(null, _originalHeartBeatTimeLimit);
+        }
+
+        // The heart beat is the only check that runs unconditionally, so it is what has to notice a connection
+        // that never came back. It used to report a healthy beat whenever it was not connected, which meant the
+        // detector was switched off by the very condition it exists to detect: a gateway restart that failed to
+        // reconnect kept the algorithm running for three days, silently rejecting every order, because no
+        // disconnect was ever reported to the brokerage message handler.
+        [Test]
+        public void HeartBeatReportsFailureWhenTheConnectionIsLostWithoutAnExpectedReason()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            // no client at all, so IsConnected is false: this is the state the deployment sat in for three days
+            var automater = CreateInertAutomater();
+            SetPrivateField(brokerage, "_ibAutomater", automater);
+
+            Assert.IsFalse(InvokeIsConnected(brokerage), "the fixture must start from a disconnected state");
+
+            // IsWithinScheduledServerResetTimes() reads the wall clock and is the one input that cannot be
+            // injected. Skipping is better than asserting the opposite branch here: it keeps the test from
+            // silently passing without exercising the case it exists for.
+            if (automater.IsWithinScheduledServerResetTimes())
+            {
+                Assert.Ignore("within the IB scheduled server reset times, a disconnection would be expected right now");
+            }
+
+            Assert.IsFalse(InvokeHeartBeat(brokerage),
+                "a lost connection that nothing accounts for must be reported as a failed beat");
+        }
+
+        // The counterpart of the test above and the reason it cannot simply alarm on every dropped connection:
+        // the gateway restarts every night at 23:45 and the socket is torn down on purpose each time. Those
+        // windows reconnect within about a minute and must not be reported, otherwise every deployment would be
+        // killed nightly.
+        [TestCase("_isDisposeCalled", TestName = "HeartBeatStaysQuietWhileDisposing")]
+        [TestCase("IsConnecting", TestName = "HeartBeatStaysQuietWhileConnecting")]
+        [TestCase("_gatewayRestartPending", TestName = "HeartBeatStaysQuietWhileWaitingForTheGatewayRestart")]
+        public void HeartBeatDoesNotReportAnExpectedDisconnection(string expectedReasonField)
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            SetPrivateField(brokerage, "_ibAutomater", CreateInertAutomater());
+
+            if (expectedReasonField == "IsConnecting")
+            {
+                // a connection attempt holds IsConnected false for as long as it runs, which is minutes when
+                // it needs a 2FA confirmation
+                GetStateManager(brokerage).IsConnecting = true;
+            }
+            else
+            {
+                SetPrivateField(brokerage, expectedReasonField, true);
+            }
+
+            Assert.IsFalse(InvokeIsConnected(brokerage));
+            Assert.IsTrue(InvokeHeartBeat(brokerage), "an expected disconnection must not be reported as a failed beat");
+        }
+
+        // DefaultBrokerageMessageHandler disposes its pending countdown and starts a new one every time it
+        // receives a disconnect message, so repeating it while still down would keep pushing the algorithm
+        // shutdown into the future and never stop anything. It has to be raised once per disconnection.
+        [Test]
+        public void DisconnectIsReportedOncePerDisconnection()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var messages = new List<BrokerageMessageEvent>();
+            brokerage.Message += (_, message) => messages.Add(message);
+
+            InvokeOnDisconnected(brokerage, "first");
+            InvokeOnDisconnected(brokerage, "second");
+            InvokeOnDisconnected(brokerage, "third");
+
+            Assert.AreEqual(1, messages.Count(x => x.Type == BrokerageMessageType.Disconnect));
+            Assert.AreEqual("first", messages.Single(x => x.Type == BrokerageMessageType.Disconnect).Message);
+        }
+
+        // ...and once we are back the next disconnection is a new episode that has to be reported again,
+        // otherwise the safety net only ever works once per deployment.
+        [Test]
+        public void ReconnectingReArmsTheDisconnectReport()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var messages = new List<BrokerageMessageEvent>();
+            brokerage.Message += (_, message) => messages.Add(message);
+
+            InvokeOnDisconnected(brokerage, "lost");
+            InvokeOnReconnected(brokerage, "back");
+            InvokeOnDisconnected(brokerage, "lost again");
+
+            Assert.AreEqual(2, messages.Count(x => x.Type == BrokerageMessageType.Disconnect));
+            Assert.AreEqual(1, messages.Count(x => x.Type == BrokerageMessageType.Reconnect));
+            CollectionAssert.AreEqual(
+                new[] { BrokerageMessageType.Disconnect, BrokerageMessageType.Reconnect, BrokerageMessageType.Disconnect },
+                messages.Select(x => x.Type));
+        }
+
+        // ...and a reset is not a reconnection: it runs on every gateway exit, so re-arming there would emit a
+        // disconnect per restart cycle and each one restarts the countdown the report exists to trigger.
+        [Test]
+        public void ResettingTheStateDoesNotReArmTheDisconnectReport()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var messages = new List<BrokerageMessageEvent>();
+            brokerage.Message += (_, message) => messages.Add(message);
+
+            InvokeOnDisconnected(brokerage, "lost");
+            GetStateManager(brokerage).Reset();
+            InvokeOnDisconnected(brokerage, "still lost");
+
+            Assert.AreEqual(1, messages.Count(x => x.Type == BrokerageMessageType.Disconnect));
+        }
+
+        // The transaction handler invalidates the order itself when PlaceOrder fails, but only with a generic
+        // "Brokerage failed to place orders: [20]" that never says why. It appends the exception message to it,
+        // so throwing is what carries the actual cause without reporting success for a rejected order.
+        [Test]
+        public void PlaceOrderWhenDisconnectedThrowsWithTheReason()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var messages = new List<BrokerageMessageEvent>();
+            var orderEvents = new List<OrderEvent>();
+            brokerage.Message += (_, message) => messages.Add(message);
+            brokerage.OrdersStatusChanged += (_, events) => orderEvents.AddRange(events);
+
+            Assert.IsFalse(brokerage.IsConnected);
+
+            var order = new MarketOrder(Symbols.SPY, -19454, DateTime.UtcNow);
+            var exception = Assert.Throws<InvalidOperationException>(() => brokerage.PlaceOrder(order));
+
+            Assert.AreEqual("Orders cannot be submitted when disconnected.", exception.Message);
+            // the transaction handler raises the single invalid order event, we must not raise a duplicate
+            CollectionAssert.IsEmpty(orderEvents);
+            // the brokerage level warning is still raised, it is what support greps for by code
+            Assert.AreEqual(1, messages.Count(x => x.Code == "PlaceOrderWhenDisconnected"));
+        }
+
+        // ...and the throw above is only worth anything if the transaction handler carries the reason out to the
+        // ticket, which is what the algorithm actually reads. Drives the real handler to prove the round trip.
+        [Test]
+        public void PlaceOrderWhenDisconnectedReportsTheReasonOnTheTicket()
+        {
+            var algorithm = new AlgorithmStub();
+            var equity = algorithm.AddEquity("SPY");
+            equity.SetMarketPrice(new Tick { Value = 100m });
+            algorithm.SetFinishedWarmingUp();
+
+            // the parameterless constructor skips the subscription validation, PlaceOrder only needs IsConnected
+            using var brokerage = new InteractiveBrokersBrokerage();
+            Assert.IsFalse(brokerage.IsConnected);
+
+            var transactionHandler = new SynchronousTransactionHandler();
+            transactionHandler.Initialize(algorithm, brokerage, new TestResultHandler());
+            algorithm.Transactions.SetOrderProcessor(transactionHandler);
+
+            try
+            {
+                var request = new SubmitOrderRequest(OrderType.Market, equity.Symbol.SecurityType, equity.Symbol, 1m, 0, 0,
+                    DateTime.UtcNow, string.Empty);
+                algorithm.Transactions.SetOrderId(request);
+
+                var ticket = transactionHandler.Process(request);
+                // the queue is drained by the engine loop, which is not running here
+                transactionHandler.HandleOrderRequest(request);
+
+                Assert.AreEqual(OrderStatus.Invalid, ticket.Status);
+                Assert.IsTrue(ticket.SubmitRequest.Response.IsError, "a rejected order must not report a successful response");
+                StringAssert.Contains("Orders cannot be submitted when disconnected.", ticket.SubmitRequest.Response.ErrorMessage);
+            }
+            finally
+            {
+                transactionHandler.Exit();
+            }
+        }
+
+        /// <summary>
+        /// No worker threads, so the request is only ever processed by the explicit HandleOrderRequest call above.
+        /// </summary>
+        private class SynchronousTransactionHandler : BrokerageTransactionHandler
+        {
+            protected override bool SynchronousProcessing => true;
+        }
+
+        /// <summary>
+        /// An IBAutomater that is only ever asked about the scheduled reset times, it is never started so no
+        /// gateway process is involved.
+        /// </summary>
+        private static QuantConnect.IBAutomater.IBAutomater CreateInertAutomater()
+        {
+            return new QuantConnect.IBAutomater.IBAutomater(
+                ibDirectory: string.Empty,
+                ibVersion: string.Empty,
+                userName: string.Empty,
+                password: string.Empty,
+                tradingMode: "paper",
+                portNumber: 4002,
+                exportIbGatewayLogs: false);
+        }
+
+        private static bool InvokeHeartBeat(InteractiveBrokersBrokerage brokerage)
+        {
+            // a tiny wait keeps the test fast, the value only drives the internal wait handles
+            return (bool)InvokePrivate(brokerage, "HeartBeat", new object[] { 1 });
+        }
+
+        private static void InvokeOnDisconnected(InteractiveBrokersBrokerage brokerage, string message)
+        {
+            InvokePrivate(brokerage, "OnDisconnected", new object[] { message });
+        }
+
+        private static void InvokeOnReconnected(InteractiveBrokersBrokerage brokerage, string message)
+        {
+            InvokePrivate(brokerage, "OnReconnected", new object[] { message });
+        }
+
+        private static bool InvokeIsConnected(InteractiveBrokersBrokerage brokerage)
+        {
+            return brokerage.IsConnected;
+        }
+
+        private static InteractiveBrokersStateManager GetStateManager(InteractiveBrokersBrokerage brokerage)
+        {
+            return (InteractiveBrokersStateManager)typeof(InteractiveBrokersBrokerage)
+                .GetField("_stateManager", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(brokerage);
+        }
+
+        private static object InvokePrivate(object instance, string name, object[] arguments)
+        {
+            return instance.GetType()
+                .GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(instance, arguments);
+        }
+
+        private static void SetPrivateField(object instance, string name, object value)
+        {
+            instance.GetType()
+                .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(instance, value);
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         // killed nightly.
         [TestCase("_isDisposeCalled", TestName = "HeartBeatStaysQuietWhileDisposing")]
         [TestCase("IsConnecting", TestName = "HeartBeatStaysQuietWhileConnecting")]
-        [TestCase("_gatewayRestartPending", TestName = "HeartBeatStaysQuietWhileWaitingForTheGatewayRestart")]
+        [TestCase("BeginGatewayRestart", TestName = "HeartBeatStaysQuietWhileTheGatewayRestartIsRunning")]
         public void HeartBeatDoesNotReportAnExpectedDisconnection(string expectedReasonField)
         {
             using var brokerage = new InteractiveBrokersBrokerage();
@@ -97,6 +97,10 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 // it needs a 2FA confirmation
                 GetStateManager(brokerage).IsConnecting = true;
             }
+            else if (expectedReasonField == "BeginGatewayRestart")
+            {
+                BeginGatewayRestart(brokerage);
+            }
             else
             {
                 SetPrivateField(brokerage, expectedReasonField, true);
@@ -104,6 +108,72 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 
             Assert.IsFalse(InvokeIsConnected(brokerage));
             Assert.IsTrue(InvokeHeartBeat(brokerage), "an expected disconnection must not be reported as a failed beat");
+        }
+
+        // A restart is accounted for until it finishes, not until its wait is over: the minutes a cold start
+        // spends waiting for the weekly 2FA confirmation used to be reported as a lost connection.
+        [Test]
+        public void HeartBeatStaysQuietUntilTheGatewayRestartFinishes()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var automater = CreateInertAutomater();
+            SetPrivateField(brokerage, "_ibAutomater", automater);
+
+            if (automater.IsWithinScheduledServerResetTimes())
+            {
+                Assert.Ignore("within the IB scheduled server reset times, a disconnection would be expected right now");
+            }
+
+            BeginGatewayRestart(brokerage);
+            Assert.IsTrue(InvokeHeartBeat(brokerage), "a restart that has not finished accounts for the disconnection");
+
+            EndGatewayRestart(brokerage);
+            Assert.IsFalse(InvokeHeartBeat(brokerage),
+                "once the restart is finished a lost connection is a real loss again");
+        }
+
+        // The weekly restart stops the gateway, which makes the exit handler start its own while the weekly one
+        // is still running. A flag would be cleared by whichever finished first, leaving the other unaccounted.
+        [Test]
+        public void OverlappingGatewayRestartsAreAccountedForUntilTheLastOneFinishes()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var automater = CreateInertAutomater();
+            SetPrivateField(brokerage, "_ibAutomater", automater);
+
+            if (automater.IsWithinScheduledServerResetTimes())
+            {
+                Assert.Ignore("within the IB scheduled server reset times, a disconnection would be expected right now");
+            }
+
+            BeginGatewayRestart(brokerage);
+            BeginGatewayRestart(brokerage);
+
+            EndGatewayRestart(brokerage);
+            Assert.IsTrue(InvokeHeartBeat(brokerage), "the restart still running must keep accounting for the disconnection");
+
+            EndGatewayRestart(brokerage);
+            Assert.IsFalse(InvokeHeartBeat(brokerage), "with both finished the lost connection is a real loss again");
+        }
+
+        // A reconnection ends every restart in flight at once, so the ones still running would push the count
+        // negative and the next restart would be one short of accounting for itself.
+        [Test]
+        public void AGatewayRestartAfterAReconnectionIsStillAccountedFor()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            var automater = CreateInertAutomater();
+            SetPrivateField(brokerage, "_ibAutomater", automater);
+
+            BeginGatewayRestart(brokerage);
+            InvokeOnReconnected(brokerage, "back");
+            // the restart that was in flight finishes after the reconnection already ended it
+            EndGatewayRestart(brokerage);
+
+            BeginGatewayRestart(brokerage);
+
+            Assert.IsFalse(InvokeIsConnected(brokerage));
+            Assert.IsTrue(InvokeHeartBeat(brokerage), "the new restart must account for its own disconnection");
         }
 
         // DefaultBrokerageMessageHandler disposes its pending countdown and starts a new one every time it
@@ -260,6 +330,16 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         private static void InvokeOnReconnected(InteractiveBrokersBrokerage brokerage, string message)
         {
             InvokePrivate(brokerage, "OnReconnected", new object[] { message });
+        }
+
+        private static void BeginGatewayRestart(InteractiveBrokersBrokerage brokerage)
+        {
+            InvokePrivate(brokerage, "BeginGatewayRestart", Array.Empty<object>());
+        }
+
+        private static void EndGatewayRestart(InteractiveBrokersBrokerage brokerage)
+        {
+            InvokePrivate(brokerage, "EndGatewayRestart", Array.Empty<object>());
         }
 
         private static bool InvokeIsConnected(InteractiveBrokersBrokerage brokerage)

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
@@ -249,6 +249,24 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.AreEqual(expectedAction, action.ToString());
         }
 
+        // The weekly restart is what gets the 2FA confirmation requested at the time the user picked. It used to
+        // skip on the gateway having exited that day, but a gateway that exits comes back on the session token
+        // and asks for nothing: on the two Sundays reported the token expiry exit at 23:45 made the 23:54 check
+        // skip, the confirmation was pushed a week out and the deployment traded on a session nobody renewed.
+        [Test]
+        public void TheWeeklyRestartRunsUntilTheGatewayHasAuthenticatedToday()
+        {
+            // the 23:54 check of the Sunday in the report, five minutes before the configured 23:59
+            var utcNow = new DateTime(2026, 8, 2, 23, 54, 0, DateTimeKind.Utc);
+
+            Assert.IsTrue(ShouldRunWeeklyRestart(default, utcNow), "a gateway that never authenticated must restart");
+            // the deployment logged in on the Friday, two days before: this is the case that was being skipped
+            Assert.IsTrue(ShouldRunWeeklyRestart(new DateTime(2026, 7, 31, 20, 51, 0, DateTimeKind.Utc), utcNow),
+                "the last login was on Friday, the weekly confirmation is due");
+            // and once it has logged in today there is nothing left for the weekly restart to ask for
+            Assert.IsFalse(ShouldRunWeeklyRestart(new DateTime(2026, 8, 2, 23, 46, 0, DateTimeKind.Utc), utcNow));
+        }
+
         // The transaction handler invalidates the order itself when PlaceOrder fails, but only with a generic
         // "Brokerage failed to place orders: [20]" that never says why. It appends the exception message to it,
         // so throwing is what carries the actual cause without reporting success for a rejected order.
@@ -349,6 +367,13 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         private static void InvokeOnReconnected(InteractiveBrokersBrokerage brokerage, string message)
         {
             InvokePrivate(brokerage, "OnReconnected", new object[] { message });
+        }
+
+        private static bool ShouldRunWeeklyRestart(DateTime lastAuthenticationTimeUtc, DateTime utcNow)
+        {
+            return (bool)typeof(InteractiveBrokersBrokerage)
+                .GetMethod("ShouldRunWeeklyRestart", BindingFlags.NonPublic | BindingFlags.Static)
+                .Invoke(null, new object[] { lastAuthenticationTimeUtc, utcNow });
         }
 
         private static void BeginGatewayRestart(InteractiveBrokersBrokerage brokerage)

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
@@ -230,6 +230,25 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.AreEqual(1, messages.Count(x => x.Type == BrokerageMessageType.Disconnect));
         }
 
+        // A running gateway is not a working one. The restart that is due after a gateway exit used to skip on
+        // "IBAutomater is already running", which answers whether the process is alive when the question is
+        // whether the brokerage is connected: the gateway left up but unauthenticated by a failed weekly restart
+        // answered yes, the restart was skipped, and the deployment sat disconnected for three days.
+        [TestCase(false, false, false, "Start", TestName = "AGatewayThatIsNotRunningIsStarted")]
+        [TestCase(false, true, false, "Start", TestName = "AGatewayThatIsNotRunningIsStartedEvenIfWeAreConnected")]
+        [TestCase(true, true, false, "Skip", TestName = "ARunningAndConnectedGatewayIsLeftAlone")]
+        [TestCase(true, false, false, "Replace", TestName = "ARunningGatewayThatTakesNoConnectionIsReplaced")]
+        [TestCase(true, false, true, "Skip", TestName = "AGatewayIsOnlyReplacedOncePerOutage")]
+        public void TheRestartActionFollowsTheConnectionAndNotTheProcess(bool isRunning, bool isConnected,
+            bool alreadyReplaced, string expectedAction)
+        {
+            var action = typeof(InteractiveBrokersBrokerage)
+                .GetMethod("GetGatewayRestartAction", BindingFlags.NonPublic | BindingFlags.Static)
+                .Invoke(null, new object[] { isRunning, isConnected, alreadyReplaced });
+
+            Assert.AreEqual(expectedAction, action.ToString());
+        }
+
         // The transaction handler invalidates the order itself when PlaceOrder fails, but only with a generic
         // "Brokerage failed to place orders: [20]" that never says why. It appends the exception message to it,
         // so throwing is what carries the actual cause without reporting success for a rejected order.

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageConnectionTests.cs
@@ -234,17 +234,21 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         // "IBAutomater is already running", which answers whether the process is alive when the question is
         // whether the brokerage is connected: the gateway left up but unauthenticated by a failed weekly restart
         // answered yes, the restart was skipped, and the deployment sat disconnected for three days.
-        [TestCase(false, false, false, "Start", TestName = "AGatewayThatIsNotRunningIsStarted")]
-        [TestCase(false, true, false, "Start", TestName = "AGatewayThatIsNotRunningIsStartedEvenIfWeAreConnected")]
-        [TestCase(true, true, false, "Skip", TestName = "ARunningAndConnectedGatewayIsLeftAlone")]
-        [TestCase(true, false, false, "Replace", TestName = "ARunningGatewayThatTakesNoConnectionIsReplaced")]
-        [TestCase(true, false, true, "Skip", TestName = "AGatewayIsOnlyReplacedOncePerOutage")]
+        [TestCase(false, false, false, false, "Start", TestName = "AGatewayThatIsNotRunningIsStarted")]
+        [TestCase(false, true, false, false, "Start", TestName = "AGatewayThatIsNotRunningIsStartedEvenIfWeAreConnected")]
+        [TestCase(true, true, false, false, "Skip", TestName = "ARunningAndConnectedGatewayIsLeftAlone")]
+        [TestCase(true, false, false, false, "Replace", TestName = "ARunningGatewayThatTakesNoConnectionIsReplaced")]
+        [TestCase(true, false, true, false, "Skip", TestName = "AGatewayIsOnlyReplacedOncePerOutage")]
+        // ...and a gateway under another restart is left alone: replacing one waiting on its weekly 2FA
+        // confirmation would kill that login to request a second one
+        [TestCase(true, false, false, true, "Skip", TestName = "AGatewayUnderAnotherRestartIsLeftAlone")]
+        [TestCase(false, false, false, true, "Skip", TestName = "AGatewayUnderAnotherRestartIsLeftAloneEvenIfItIsNotRunning")]
         public void TheRestartActionFollowsTheConnectionAndNotTheProcess(bool isRunning, bool isConnected,
-            bool alreadyReplaced, string expectedAction)
+            bool alreadyReplaced, bool anotherRestartPending, string expectedAction)
         {
             var action = typeof(InteractiveBrokersBrokerage)
                 .GetMethod("GetGatewayRestartAction", BindingFlags.NonPublic | BindingFlags.Static)
-                .Invoke(null, new object[] { isRunning, isConnected, alreadyReplaced });
+                .Invoke(null, new object[] { isRunning, isConnected, alreadyReplaced, anotherRestartPending });
 
             Assert.AreEqual(expectedAction, action.ToString());
         }

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageDisconnectionLiveTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageDisconnectionLiveTests.cs
@@ -1,0 +1,193 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.InteractiveBrokers;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Logging;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
+{
+    [TestFixture]
+    [Explicit("Requires a configured IB Gateway. Kills it and waits for the heart beat to notice, ~10 minutes.")]
+    public class InteractiveBrokersBrokerageDisconnectionLiveTests
+    {
+        // Reproduces the start of the outage in issue #246: the gateway process dies, so the API socket is
+        // reset and no IB error 1100 is ever delivered. That leaves the heart beat as the only thing that can
+        // notice, and it used to report a healthy beat whenever it was not connected, so nothing was ever
+        // reported and the algorithm kept trading blind. A Disconnect must reach the message handler, which is
+        // what arms its countdown to stop the algorithm.
+        [Test]
+        public void ReportsTheDisconnectionWhenTheGatewayDiesAndDoesNotComeBack()
+        {
+            Log.LogHandler = new NUnitLogHandler();
+
+            var algorithm = new AlgorithmStub();
+            var brokerage = new InteractiveBrokersBrokerage(algorithm, new OrderProvider(), algorithm.Portfolio);
+            brokerage.Connect();
+
+            Assert.IsTrue(brokerage.IsConnected, "the gateway has to be up before the test can take it down");
+
+            // the heart beat deliberately stays quiet while the gateway daily restart or the IB server reset
+            // times account for being down, and this test is about the case where nothing accounts for it.
+            // Running inside one of those windows would prove nothing, so skip instead. Note the check is made
+            // once: starting the test shortly before either window can still drift into it.
+            if (IsWithinAWindowWhereBeingDownIsExpected(brokerage, out var reason))
+            {
+                Assert.Ignore($"a disconnection would be expected right now ({reason}), run this earlier in the day");
+            }
+
+            using var disconnected = new ManualResetEventSlim(false);
+            brokerage.Message += (_, message) =>
+            {
+                if (message.Type == BrokerageMessageType.Disconnect)
+                {
+                    disconnected.Set();
+                }
+            };
+
+            // Killing it once is not enough: the exit schedules a restart a few minutes later and a gateway
+            // that comes back would reconnect before the heart beat ever reported anything. Holding it down is
+            // what reproduces the outage, where the restart never produced a usable gateway again.
+            var killer = new GatewayKiller(brokerage);
+            try
+            {
+                // the exit schedules a restart five minutes out and the heart beat stays quiet until it has run,
+                // then waits two minutes and confirms with a six minute one, so the kill takes a while to surface
+                Assert.IsTrue(disconnected.Wait(TimeSpan.FromMinutes(20)), "the lost connection was never reported");
+                Assert.IsFalse(brokerage.IsConnected);
+            }
+            finally
+            {
+                // Disposing stops the gateway, which needs the IBAutomater lock, and IBAutomater holds that lock
+                // while relaunching the gateway we keep killing, waiting on an initialization that never
+                // finishes. Killing is left running so those relaunches fail fast and release it, and the bound
+                // means a teardown that gets stuck anyway reports instead of hanging the run.
+                DisposeWithin(brokerage, TimeSpan.FromMinutes(2));
+                killer.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Disposes within the given time, reporting rather than blocking the run forever when it does not.
+        /// </summary>
+        /// <remarks>
+        /// Reported through the log rather than Assert.Warn: a warning outcome is not a pass, the adapter
+        /// counts it as skipped, and teardown must not decide the result of what the test asserted.
+        /// </remarks>
+        private static void DisposeWithin(IDisposable disposable, TimeSpan timeout)
+        {
+            var disposal = Task.Run(() =>
+            {
+                try
+                {
+                    disposable.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    Log.Error(exception, "DisposeWithin()");
+                }
+            });
+
+            if (!disposal.Wait(timeout))
+            {
+                Log.Error($"DisposeWithin(): timed out after {timeout} disposing the brokerage, " +
+                    "an IB Gateway process may still be running. IBAutomater holds its lock while relaunching " +
+                    "the gateway, and Stop() waits for that lock.");
+            }
+        }
+
+        /// <summary>
+        /// The two wall clock driven reasons the heart beat has to stay quiet, which cannot be injected.
+        /// </summary>
+        private static bool IsWithinAWindowWhereBeingDownIsExpected(InteractiveBrokersBrokerage brokerage, out string reason)
+        {
+            var automater = (QuantConnect.IBAutomater.IBAutomater)typeof(InteractiveBrokersBrokerage)
+                .GetField("_ibAutomater", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(brokerage);
+            var heartBeatTimeLimit = (TimeSpan)typeof(InteractiveBrokersBrokerage)
+                .GetField("_heartBeatTimeLimit", BindingFlags.NonPublic | BindingFlags.Static)
+                .GetValue(null);
+
+            reason = null;
+            if (automater.IsWithinScheduledServerResetTimes())
+            {
+                reason = "within the IB scheduled server reset times";
+            }
+            else if (DateTime.Now.TimeOfDay >= heartBeatTimeLimit)
+            {
+                reason = "close to the gateway daily restart";
+            }
+
+            return reason != null;
+        }
+
+        /// <summary>
+        /// Kills the IB Gateway process, and any replacement IBAutomater starts, until disposed. Reaches for
+        /// IBAutomater's own process handle so nothing else on the machine can be matched by mistake.
+        /// </summary>
+        private sealed class GatewayKiller : IDisposable
+        {
+            private readonly CancellationTokenSource _cancellationTokenSource = new();
+            private readonly Task _task;
+
+            public GatewayKiller(InteractiveBrokersBrokerage brokerage)
+            {
+                var automater = typeof(InteractiveBrokersBrokerage)
+                    .GetField("_ibAutomater", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetValue(brokerage);
+                var processField = automater.GetType().GetField("_process", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                _task = Task.Run(() =>
+                {
+                    while (!_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            if (processField.GetValue(automater) is Process process && !process.HasExited)
+                            {
+                                Log.Trace($"GatewayKiller: killing IBGateway process {process.Id}");
+                                process.Kill();
+                            }
+                        }
+                        catch (Exception exception)
+                        {
+                            // the process can exit between the check and the kill, and the handle can be
+                            // swapped by a restart, neither is a problem: the next pass picks it up
+                            Log.Trace($"GatewayKiller: {exception.Message}");
+                        }
+
+                        _cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(2));
+                    }
+                });
+            }
+
+            public void Dispose()
+            {
+                _cancellationTokenSource.Cancel();
+                _task.Wait(TimeSpan.FromSeconds(10));
+                _cancellationTokenSource.Dispose();
+            }
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -254,6 +254,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private DateTime _lastIBAutomaterExitTime;
         private readonly object _lastIBAutomaterExitTimeLock = new object();
 
+        // the wait before restarting a gateway that exited, minutes or hours. IsRestartInProgress() cannot
+        // speak for it, StopGatewayRestartTask() cancels the token it reads before the wait begins
+        private volatile bool _gatewayRestartPending;
+
         private volatile bool _isDisposeCalled;
         private bool _isInitialized;
         private bool _pastFirstConnection;
@@ -435,19 +439,20 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <returns>True if the request for a new order has been placed, false otherwise</returns>
         public override bool PlaceOrder(Order order)
         {
+            // outside of the try below on purpose: the transaction handler appends the exception message to its
+            // generic "Brokerage failed to place orders: [id]", catching it here would lose the reason
+            if (!IsConnected)
+            {
+                const string message = "Orders cannot be submitted when disconnected.";
+
+                Log.Trace($"InteractiveBrokersBrokerage.PlaceOrder(): {message} Symbol: {order.Symbol.Value} Quantity: {order.Quantity}. Id: {order.Id}");
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "PlaceOrderWhenDisconnected", message));
+
+                throw new InvalidOperationException(message);
+            }
+
             try
             {
-                if (!IsConnected)
-                {
-                    Log.Trace($"InteractiveBrokersBrokerage.PlaceOrder(): Symbol: {order.Symbol.Value} Quantity: {order.Quantity}. Id: {order.Id}");
-                    OnMessage(
-                        new BrokerageMessageEvent(
-                            BrokerageMessageType.Warning,
-                            "PlaceOrderWhenDisconnected",
-                            "Orders cannot be submitted when disconnected."));
-                    return false;
-                }
-
                 IBPlaceOrder(order, true);
                 return true;
             }
@@ -1047,7 +1052,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 RestoreDataSubscriptions();
 
                 // we need to tell the DefaultBrokerageMessageHandler we are connected else he will kill us
-                OnMessage(BrokerageMessageEvent.Reconnected("Connect() finished successfully"));
+                OnReconnected("Connect() finished successfully");
             }
             else
             {
@@ -1063,26 +1068,77 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 return true;
             }
 
-            if (!_isDisposeCalled &&
-                !_ibAutomater.IsWithinScheduledServerResetTimes() &&
-                IsConnected &&
-                // do not run heart beat if we are close to daily restarts
-                DateTime.Now.TimeOfDay < _heartBeatTimeLimit &&
-                // do not run heart beat if we are restarting
-                !IsRestartInProgress())
+            // why being disconnected would be expected, null when nothing accounts for it. Most specific
+            // first, several hold at once during a nightly restart and the narrow one is worth more in a log
+            var expected = true switch
             {
-                _currentTimeEvent.Reset();
-                // request current time to the server
-                _client.ClientSocket.reqCurrentTime();
-                var result = _currentTimeEvent.WaitOne(Time.GetSecondUnevenWait(waitTimeMs), _cancellationTokenSource.Token);
-                if (!result)
+                _ when _isDisposeCalled => "we are disposed",
+                _ when _gatewayRestartPending => "waiting for the scheduled restart after the gateway exited",
+                // a connection attempt takes minutes when it needs a 2FA confirmation
+                _ when _stateManager.IsConnecting => "a connection attempt is in progress",
+                // do not run heart beat if we are restarting
+                _ when IsRestartInProgress() => "a gateway restart is in progress",
+                // do not run heart beat if we are close to daily restarts
+                _ when DateTime.Now.TimeOfDay >= _heartBeatTimeLimit => "close to the gateway daily restart",
+                _ when _ibAutomater.IsWithinScheduledServerResetTimes() => "within the IB scheduled server reset times",
+                _ => null
+            };
+
+            if (expected != null)
+            {
+                if (!IsConnected)
                 {
-                    Log.Error("InteractiveBrokersBrokerage.HeartBeat(): failed!", overrideMessageFloodProtection: true);
+                    // says which reason answered, so a quiet beat can be told from one hiding a real loss
+                    Log.Trace($"InteractiveBrokersBrokerage.HeartBeat(): not connected, but it is expected: {expected}");
                 }
-                return result;
+                // a probe this close to a restart fails whether or not anything is wrong, so skip it
+                return true;
             }
-            // expected
-            return true;
+
+            if (!IsConnected)
+            {
+                // a dropped connection with nothing to account for it is a real loss, reporting it as a healthy
+                // beat is what kept a gateway restart that never came back unnoticed for three days
+                Log.Error("InteractiveBrokersBrokerage.HeartBeat(): not connected!", overrideMessageFloodProtection: true);
+                return false;
+            }
+
+            _currentTimeEvent.Reset();
+            // request current time to the server
+            _client.ClientSocket.reqCurrentTime();
+            var result = _currentTimeEvent.WaitOne(Time.GetSecondUnevenWait(waitTimeMs), _cancellationTokenSource.Token);
+            if (!result)
+            {
+                Log.Error("InteractiveBrokersBrokerage.HeartBeat(): failed!", overrideMessageFloodProtection: true);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Tells the brokerage message handler the connection was lost, once per disconnection: it restarts its
+        /// countdown to stop the algorithm on every disconnect message, so repeating it would defer the shutdown.
+        /// </summary>
+        private void OnDisconnected(string message)
+        {
+            if (_stateManager.DisconnectReported)
+            {
+                return;
+            }
+            _stateManager.DisconnectReported = true;
+
+            OnMessage(BrokerageMessageEvent.Disconnected(message));
+        }
+
+        /// <summary>
+        /// Tells the brokerage message handler the connection was restored, cancelling any pending shutdown.
+        /// </summary>
+        private void OnReconnected(string message)
+        {
+            _stateManager.DisconnectReported = false;
+            // whatever we were waiting for is over, being disconnected from here on is not accounted for
+            _gatewayRestartPending = false;
+
+            OnMessage(BrokerageMessageEvent.Reconnected(message));
         }
 
         private void RunHeartBeatThread()
@@ -1101,15 +1157,21 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                             if (!HeartBeat(waitTimeMs * 3))
                             {
                                 // we emit the disconnected event so that if the re connection below fails it will kill the algorithm
-                                OnMessage(BrokerageMessageEvent.Disconnected("Connection with Interactive Brokers lost. Heart beat failed."));
-                                try
+                                OnDisconnected("Connection with Interactive Brokers lost. Heart beat failed.");
+
+                                // only a socket that is up but not answering is rebuilt here, when we are already
+                                // down the gateway restart owns the recovery and racing it would fight for the socket
+                                if (IsConnected)
                                 {
-                                    Disconnect();
+                                    try
+                                    {
+                                        Disconnect();
+                                    }
+                                    catch (Exception)
+                                    {
+                                    }
+                                    Connect();
                                 }
-                                catch (Exception)
-                                {
-                                }
-                                Connect();
                             }
                             else
                             {
@@ -2094,7 +2156,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else if (errorCode == 1102)
             {
                 // Connectivity between IB and TWS has been restored - data maintained.
-                OnMessage(BrokerageMessageEvent.Reconnected(errorMsg));
+                OnReconnected(errorMsg);
 
                 _stateManager.Disconnected1100Fired = false;
                 return;
@@ -2102,7 +2164,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else if (errorCode == 1101)
             {
                 // Connectivity between IB and TWS has been restored - data lost.
-                OnMessage(BrokerageMessageEvent.Reconnected(errorMsg));
+                OnReconnected(errorMsg);
 
                 _stateManager.Disconnected1100Fired = false;
 
@@ -2253,9 +2315,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 if (!_stateManager.PreviouslyInResetTime)
                 {
                     // if we were disconnected and we're not within the reset times, send the error event
-                    OnMessage(BrokerageMessageEvent.Disconnected("Connection with Interactive Brokers lost. " +
-                                                                 "This could be because of internet connectivity issues or a log in from another location."
-                        ));
+                    OnDisconnected("Connection with Interactive Brokers lost. " +
+                                   "This could be because of internet connectivity issues or a log in from another location.");
                 }
             }
             else
@@ -5216,7 +5277,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     _ibAutomater.Stop();
                     var message = "2FA authentication confirmation required to reconnect.";
-                    OnMessage(BrokerageMessageEvent.Disconnected(message));
+                    OnDisconnected(message);
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.ActionRequired, "2FAAuthRequired", message));
                 });
             }
@@ -5434,10 +5495,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): Delay before restart: {delay:d'd 'h'h 'm'm 's's'}");
 
+                // being disconnected until the restart below runs is expected
+                _gatewayRestartPending = true;
+
                 Task.Delay(delay).ContinueWith(_ =>
                 {
                     try
                     {
+                        _gatewayRestartPending = false;
+
                         // We won't trigger a restart if the automater was already started in the meantime
                         // or if there was an error starting it. If it's recoverable, it will be restarted
                         // by the user action somewhere else

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -254,10 +254,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private DateTime _lastIBAutomaterExitTime;
         private readonly object _lastIBAutomaterExitTimeLock = new object();
 
-        // the wait before restarting a gateway that exited, minutes or hours. IsRestartInProgress() cannot
-        // speak for it, StopGatewayRestartTask() cancels the token it reads before the wait begins
-        private volatile bool _gatewayRestartPending;
-
         private volatile bool _isDisposeCalled;
         private bool _isInitialized;
         private bool _pastFirstConnection;
@@ -1073,7 +1069,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var expected = true switch
             {
                 _ when _isDisposeCalled => "we are disposed",
-                _ when _gatewayRestartPending => "waiting for the scheduled restart after the gateway exited",
+                _ when GatewayRestartPending => "a gateway restart we started has not finished yet",
                 // a connection attempt takes minutes when it needs a 2FA confirmation
                 _ when _stateManager.IsConnecting => "a connection attempt is in progress",
                 // do not run heart beat if we are restarting
@@ -1114,6 +1110,43 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             return result;
         }
 
+        // a count and not a flag because gateway restarts overlap: the weekly one stops the gateway, which starts
+        // the exit driven one, and whichever finished first would stop accounting for the other
+        private int _gatewayRestartPendingCount;
+
+        /// <summary>
+        /// True while a gateway restart we started is still running, which is why being disconnected is expected.
+        /// </summary>
+        private bool GatewayRestartPending => Volatile.Read(ref _gatewayRestartPendingCount) > 0;
+
+        /// <summary>
+        /// Marks the start of a gateway restart we drive: the disconnection it begins with, the wait before it,
+        /// the start, minutes when it needs a 2FA confirmation, and the connection that follows.
+        /// </summary>
+        private void BeginGatewayRestart()
+        {
+            Interlocked.Increment(ref _gatewayRestartPendingCount);
+        }
+
+        /// <summary>
+        /// Marks the end of a gateway restart we drive, reconnected or not: from here on a lost connection is
+        /// unaccounted for and the heart beat reports it.
+        /// </summary>
+        private void EndGatewayRestart()
+        {
+            int pending;
+            do
+            {
+                pending = Volatile.Read(ref _gatewayRestartPendingCount);
+                if (pending == 0)
+                {
+                    // a reconnection ended them all already, going negative would swallow the next restart
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref _gatewayRestartPendingCount, pending - 1, pending) != pending);
+        }
+
         /// <summary>
         /// Tells the brokerage message handler the connection was lost, once per disconnection: it restarts its
         /// countdown to stop the algorithm on every disconnect message, so repeating it would defer the shutdown.
@@ -1135,8 +1168,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private void OnReconnected(string message)
         {
             _stateManager.DisconnectReported = false;
-            // whatever we were waiting for is over, being disconnected from here on is not accounted for
-            _gatewayRestartPending = false;
+            // we are back, leaving a restart accounted for would keep skipping the probe
+            Interlocked.Exchange(ref _gatewayRestartPendingCount, 0);
 
             OnMessage(BrokerageMessageEvent.Reconnected(message));
         }
@@ -5420,6 +5453,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     Log.Trace($"InteractiveBrokersBrokerage.StartGatewayWeeklyRestartTask(): triggering weekly restart manually");
 
+                    // the stop below takes the connection down and the start waits for the weekly 2FA confirmation
+                    BeginGatewayRestart();
                     try
                     {
                         if (_ibAutomater.IsRunning())
@@ -5436,6 +5471,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     catch (Exception ex)
                     {
                         Log.Error(ex);
+                    }
+                    finally
+                    {
+                        // the exit event begins its own restart before this one ends, hence the count
+                        EndGatewayRestart();
                     }
                 }
 
@@ -5481,61 +5521,74 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 // IBGateway was closed by IBAutomater because the auto-restart token expired or it was closed manually (less likely)
                 Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): IBGateway close detected, restarting IBAutomater...");
 
+                // before the Disconnect() below, which waits for the message processing thread while the
+                // connection is already gone
+                BeginGatewayRestart();
                 try
-                {
-                    // disconnect immediately so orders will not be submitted to the API while waiting for reconnection
-                    Disconnect();
-                }
-                catch (Exception exception)
-                {
-                    Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): error in Disconnect(): {exception}");
-                }
-
-                var delay = GetWeeklyRestartDelay();
-
-                Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): Delay before restart: {delay:d'd 'h'h 'm'm 's's'}");
-
-                // being disconnected until the restart below runs is expected
-                _gatewayRestartPending = true;
-
-                Task.Delay(delay).ContinueWith(_ =>
                 {
                     try
                     {
-                        _gatewayRestartPending = false;
-
-                        // We won't trigger a restart if the automater was already started in the meantime
-                        // or if there was an error starting it. If it's recoverable, it will be restarted
-                        // by the user action somewhere else
-                        if (_ibAutomater.IsRunning())
-                        {
-                            Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): IBAutomater is already running, skipping restart.");
-                            return;
-                        }
-
-                        var lastResult = _ibAutomater.GetLastStartResult();
-                        if (lastResult.HasError)
-                        {
-                            Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): last IBAutomater start had error, skipping restart.");
-                            return;
-                        }
-
-                        Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): restarting...");
-
-                        var result = _ibAutomater.Start(false);
-                        CheckIbAutomaterError(result);
-
-                        // Has error but we are still running, we might be waiting for 2FA user required action after timeout, let's not connect in that case
-                        if (!result.HasError)
-                        {
-                            Connect();
-                        }
+                        // disconnect immediately so orders will not be submitted to the API while waiting for reconnection
+                        Disconnect();
                     }
                     catch (Exception exception)
                     {
-                        OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "IBAutomaterRestartError", exception.ToString()));
+                        Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): error in Disconnect(): {exception}");
                     }
-                }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
+                    var delay = GetWeeklyRestartDelay();
+
+                    Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): Delay before restart: {delay:d'd 'h'h 'm'm 's's'}");
+
+                    Task.Delay(delay).ContinueWith(_ =>
+                    {
+                        try
+                        {
+                            // We won't trigger a restart if the automater was already started in the meantime
+                            // or if there was an error starting it. If it's recoverable, it will be restarted
+                            // by the user action somewhere else
+                            if (_ibAutomater.IsRunning())
+                            {
+                                Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): IBAutomater is already running, skipping restart.");
+                                return;
+                            }
+
+                            var lastResult = _ibAutomater.GetLastStartResult();
+                            if (lastResult.HasError)
+                            {
+                                Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): last IBAutomater start had error, skipping restart.");
+                                return;
+                            }
+
+                            Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): restarting...");
+
+                            var result = _ibAutomater.Start(false);
+                            CheckIbAutomaterError(result);
+
+                            // Has error but we are still running, we might be waiting for 2FA user required action after timeout, let's not connect in that case
+                            if (!result.HasError)
+                            {
+                                Connect();
+                            }
+                        }
+                        catch (Exception exception)
+                        {
+                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "IBAutomaterRestartError", exception.ToString()));
+                        }
+                        finally
+                        {
+                            // when the start is done, not when the wait is: the cold start above spends minutes
+                            // waiting for the 2FA confirmation and ending here would report it as a lost connection
+                            EndGatewayRestart();
+                        }
+                    }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+                }
+                catch
+                {
+                    // nothing was scheduled, so nothing is going to end it
+                    EndGatewayRestart();
+                    throw;
+                }
             }
             else
             {

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -251,8 +251,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
         // The UTC time at which IBAutomater should be restarted and 2FA confirmation should be requested on Sundays (IB's weekly restart)
         private TimeSpan _weeklyRestartUtcTime;
-        private DateTime _lastIBAutomaterExitTime;
-        private readonly object _lastIBAutomaterExitTimeLock = new object();
+
+        // when the gateway last logged in from zero, which is when a 2FA confirmation is requested. Not the same
+        // as when it last exited: the nightly restart brings it back on the session token and asks for nothing
+        private DateTime _lastGatewayAuthenticationTime;
+        private readonly object _lastGatewayAuthenticationTimeLock = new object();
 
         private volatile bool _isDisposeCalled;
         private bool _isInitialized;
@@ -860,7 +863,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var lastAutomaterStartResult = _ibAutomater.GetLastStartResult();
             if (lastAutomaterStartResult.HasError)
             {
-                lastAutomaterStartResult = _ibAutomater.Start(false);
+                lastAutomaterStartResult = StartGateway();
                 CheckIbAutomaterError(lastAutomaterStartResult);
                 // There was an error but we did not throw, must be another 2FA timeout, we can't continue
                 if (lastAutomaterStartResult.HasError)
@@ -1549,7 +1552,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             try
             {
-                CheckIbAutomaterError(_ibAutomater.Start(false));
+                CheckIbAutomaterError(StartGateway());
             }
             catch
             {
@@ -5441,16 +5444,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 var restart = false;
 
-                lock (_lastIBAutomaterExitTimeLock)
+                lock (_lastGatewayAuthenticationTimeLock)
                 {
-                    // if the gateway hasn't yet exited today, we restart manually
-                    if (_lastIBAutomaterExitTime.Date < DateTime.UtcNow.Date)
+                    restart = ShouldRunWeeklyRestart(_lastGatewayAuthenticationTime, DateTime.UtcNow);
+                    if (!restart)
                     {
-                        restart = true;
-                    }
-                    else
-                    {
-                        Log.Trace($"InteractiveBrokersBrokerage.StartGatewayWeeklyRestartTask(): skip restart: gateway already exited today and should have been automatically restarted.");
+                        Log.Trace($"InteractiveBrokersBrokerage.StartGatewayWeeklyRestartTask(): skip restart: the gateway already authenticated today, at {_lastGatewayAuthenticationTime:u}.");
                     }
                 }
 
@@ -5471,7 +5470,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         {
                             // if the gateway is not running, we start it. Starting it is not connecting to it,
                             // and nothing else will: the exit event that usually does is not coming
-                            var result = _ibAutomater.Start(false);
+                            var result = StartGateway();
                             CheckIbAutomaterError(result);
 
                             if (!result.HasError)
@@ -5501,6 +5500,39 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             if (e.Data == null) return;
 
             Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterErrorDataReceived(): {e.Data}");
+        }
+
+        /// <summary>
+        /// Whether the weekly restart still has to run. It exists to get the 2FA confirmation requested at a time
+        /// the user picked, so what it skips on is having authenticated today. Skipping on having exited today is
+        /// what broke: the gateway comes back from a nightly exit on the session token, asking for nothing, and
+        /// reading that as the weekly confirmation pushed the real one a week out, every Sunday.
+        /// </summary>
+        private static bool ShouldRunWeeklyRestart(DateTime lastAuthenticationTimeUtc, DateTime utcNow)
+        {
+            return lastAuthenticationTimeUtc.Date < utcNow.Date;
+        }
+
+        /// <summary>
+        /// Starts the gateway, recording when it logs in from zero. IBAutomater returns success without doing
+        /// anything when the gateway is already running, and that is not a login, so only a start that had one
+        /// to do counts as the authentication the weekly restart is scheduled around.
+        /// </summary>
+        private StartResult StartGateway()
+        {
+            var loginRequired = !_ibAutomater.IsRunning();
+
+            var result = _ibAutomater.Start(false);
+
+            if (loginRequired && !result.HasError)
+            {
+                lock (_lastGatewayAuthenticationTimeLock)
+                {
+                    _lastGatewayAuthenticationTime = DateTime.UtcNow;
+                }
+            }
+
+            return result;
         }
 
         private enum GatewayRestartAction
@@ -5542,11 +5574,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
         private void OnIbAutomaterExited(object sender, ExitedEventArgs e)
         {
-            lock (_lastIBAutomaterExitTimeLock)
-            {
-                _lastIBAutomaterExitTime = DateTime.UtcNow;
-            }
-
             Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): Exit code: {e.ExitCode}");
 
             _stateManager.Reset();
@@ -5620,7 +5647,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                             Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): restarting...");
 
-                            var result = _ibAutomater.Start(false);
+                            var result = StartGateway();
                             CheckIbAutomaterError(result);
 
                             // Has error but we are still running, we might be waiting for 2FA user required action after timeout, let's not connect in that case

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1119,6 +1119,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </summary>
         private bool GatewayRestartPending => Volatile.Read(ref _gatewayRestartPendingCount) > 0;
 
+        // whether we already replaced a running but unconnected gateway for the current outage, cleared by a
+        // reconnection: replacing it again and again would keep a restart pending and the loss unreported
+        private volatile bool _disconnectedGatewayReplaced;
+
         /// <summary>
         /// Marks the start of a gateway restart we drive: the disconnection it begins with, the wait before it,
         /// the start, minutes when it needs a 2FA confirmation, and the connection that follows.
@@ -1170,6 +1174,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             _stateManager.DisconnectReported = false;
             // we are back, leaving a restart accounted for would keep skipping the probe
             Interlocked.Exchange(ref _gatewayRestartPendingCount, 0);
+            _disconnectedGatewayReplaced = false;
 
             OnMessage(BrokerageMessageEvent.Reconnected(message));
         }
@@ -5464,8 +5469,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         }
                         else
                         {
-                            // if the gateway is not running, we start it
-                            CheckIbAutomaterError(_ibAutomater.Start(false));
+                            // if the gateway is not running, we start it. Starting it is not connecting to it,
+                            // and nothing else will: the exit event that usually does is not coming
+                            var result = _ibAutomater.Start(false);
+                            CheckIbAutomaterError(result);
+
+                            if (!result.HasError)
+                            {
+                                Connect();
+                            }
                         }
                     }
                     catch (Exception ex)
@@ -5489,6 +5501,43 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             if (e.Data == null) return;
 
             Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterErrorDataReceived(): {e.Data}");
+        }
+
+        private enum GatewayRestartAction
+        {
+            /// <summary>
+            /// Nothing to do, the gateway is running and connected, or we already replaced it once for this outage
+            /// </summary>
+            Skip,
+
+            /// <summary>
+            /// Start the gateway, it is not running
+            /// </summary>
+            Start,
+
+            /// <summary>
+            /// Stop the gateway so it is started from zero, it is running but takes no connection
+            /// </summary>
+            Replace
+        }
+
+        /// <summary>
+        /// What to do with a gateway once its restart is due. A running gateway is not a working one: answering
+        /// "is the process alive?" when the question is "is the brokerage connected?" is what left a deployment
+        /// disconnected for three days. Replaced at most once per outage, the second time the connection is lost
+        /// for a reason a restart does not fix and the heart beat has to be allowed to report it.
+        /// </summary>
+        private static GatewayRestartAction GetGatewayRestartAction(bool isRunning, bool isConnected, bool alreadyReplaced)
+        {
+            if (!isRunning)
+            {
+                return GatewayRestartAction.Start;
+            }
+            if (isConnected || alreadyReplaced)
+            {
+                return GatewayRestartAction.Skip;
+            }
+            return GatewayRestartAction.Replace;
         }
 
         private void OnIbAutomaterExited(object sender, ExitedEventArgs e)
@@ -5544,20 +5593,29 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     {
                         try
                         {
-                            // We won't trigger a restart if the automater was already started in the meantime
-                            // or if there was an error starting it. If it's recoverable, it will be restarted
+                            // if there was an error starting it and it's recoverable, it will be restarted
                             // by the user action somewhere else
-                            if (_ibAutomater.IsRunning())
-                            {
-                                Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): IBAutomater is already running, skipping restart.");
-                                return;
-                            }
-
                             var lastResult = _ibAutomater.GetLastStartResult();
                             if (lastResult.HasError)
                             {
                                 Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): last IBAutomater start had error, skipping restart.");
                                 return;
+                            }
+
+                            var isRunning = _ibAutomater.IsRunning();
+                            switch (GetGatewayRestartAction(isRunning, IsConnected, _disconnectedGatewayReplaced))
+                            {
+                                case GatewayRestartAction.Skip:
+                                    Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): skipping restart. IBAutomater running: {isRunning}, connected: {IsConnected}");
+                                    return;
+
+                                case GatewayRestartAction.Replace:
+                                    // stopping it makes the exit event restart it from zero, which is what
+                                    // requests the 2FA confirmation this gateway never got
+                                    Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): IBAutomater is running but not connected, stopping it.");
+                                    _disconnectedGatewayReplaced = true;
+                                    _ibAutomater.Stop();
+                                    return;
                             }
 
                             Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterExited(): restarting...");

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -1211,7 +1211,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                                     catch (Exception)
                                     {
                                     }
-                                    Connect();
+                                    try
+                                    {
+                                        Connect();
+                                    }
+                                    catch (Exception exception)
+                                    {
+                                        // the monitor outlives a failed rebuild, or the next episode would go unreported
+                                        Log.Error(exception, "HeartBeat Connect");
+                                    }
                                 }
                             }
                             else

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -5538,7 +5538,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private enum GatewayRestartAction
         {
             /// <summary>
-            /// Nothing to do, the gateway is running and connected, or we already replaced it once for this outage
+            /// Nothing to do, the gateway is running and connected, we already replaced it once for this outage,
+            /// or another restart still running owns it
             /// </summary>
             Skip,
 
@@ -5557,10 +5558,16 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// What to do with a gateway once its restart is due. A running gateway is not a working one: answering
         /// "is the process alive?" when the question is "is the brokerage connected?" is what left a deployment
         /// disconnected for three days. Replaced at most once per outage, the second time the connection is lost
-        /// for a reason a restart does not fix and the heart beat has to be allowed to report it.
+        /// for a reason a restart does not fix and the heart beat has to be allowed to report it. Never acts
+        /// under another restart still running, which may be waiting on its 2FA confirmation.
         /// </summary>
-        private static GatewayRestartAction GetGatewayRestartAction(bool isRunning, bool isConnected, bool alreadyReplaced)
+        private static GatewayRestartAction GetGatewayRestartAction(bool isRunning, bool isConnected, bool alreadyReplaced,
+            bool anotherRestartPending)
         {
+            if (anotherRestartPending)
+            {
+                return GatewayRestartAction.Skip;
+            }
             if (!isRunning)
             {
                 return GatewayRestartAction.Start;
@@ -5630,10 +5637,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                             }
 
                             var isRunning = _ibAutomater.IsRunning();
-                            switch (GetGatewayRestartAction(isRunning, IsConnected, _disconnectedGatewayReplaced))
+                            // more than this restart's own pending count means the weekly restart is mid-flight
+                            var anotherRestartPending = Volatile.Read(ref _gatewayRestartPendingCount) > 1;
+                            switch (GetGatewayRestartAction(isRunning, IsConnected, _disconnectedGatewayReplaced, anotherRestartPending))
                             {
                                 case GatewayRestartAction.Skip:
-                                    Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): skipping restart. IBAutomater running: {isRunning}, connected: {IsConnected}");
+                                    Log.Trace($"InteractiveBrokersBrokerage.OnIbAutomaterExited(): skipping restart. IBAutomater running: {isRunning}, connected: {IsConnected}, another restart pending: {anotherRestartPending}");
                                     return;
 
                                 case GatewayRestartAction.Replace:

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersStateManager.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersStateManager.cs
@@ -24,6 +24,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
     {
         private volatile bool _disconnected1100Fired;
         private volatile bool _previouslyInResetTime;
+        private volatile bool _disconnectReported;
         private readonly ManualResetEvent _connectingInProgress = new ManualResetEvent(false);
 
         /// <summary>
@@ -81,12 +82,31 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         }
 
         /// <summary>
+        /// Gets/sets whether the current disconnection was already reported. The message handler restarts its
+        /// countdown to stop the algorithm on every disconnect, so it is raised once per disconnection.
+        /// </summary>
+        public bool DisconnectReported
+        {
+            get
+            {
+                return _disconnectReported;
+            }
+
+            set
+            {
+                _disconnectReported = value;
+            }
+        }
+
+        /// <summary>
         /// Resets the state to the default values
         /// </summary>
         public void Reset()
         {
             _disconnected1100Fired = false;
             _previouslyInResetTime = false;
+            // _disconnectReported is not cleared here, only a reconnection re-arms it: this runs on every
+            // gateway exit, and one disconnect per restart cycle would keep deferring the shutdown
             _connectingInProgress.Reset();
         }
     }


### PR DESCRIPTION
Fixes #246: a deployment lost its IB connection during the Sunday gateway restart, never got it back, and kept
running for three days rejecting every order without anything reporting the loss.

One commit per defect.

### Report a connection that is lost and does not come back

`HeartBeat()` only probed while `IsConnected` was true and returned healthy otherwise, so the detector was
switched off by the very condition it exists to detect. No `Disconnect` reached `DefaultBrokerageMessageHandler`,
its countdown to stop the algorithm was never armed, and the deployment traded blind.

Being disconnected is now a failed beat unless something accounts for it: disposing, an in-flight connection
attempt, the IB server reset times, the gateway daily restart, a restart in progress, or a restart we started.
Raised **once per disconnection**, because the message handler replaces its pending countdown on every disconnect
message, and re-armed only by a reconnection. An order refused while disconnected now fails with the reason.

### Account for a gateway restart while it runs, not while it waits

The flag saying a disconnection was expected was set *after* the `Disconnect()` that begins a restart and cleared
*before* the `Start()` that ends it, so the minutes a cold start spends waiting for a 2FA confirmation were
reported as a lost connection and could stop the algorithm being recovered. It now covers the whole restart, and
is a count rather than a flag because restarts overlap: the weekly one stops the gateway, which starts the exit
driven one before the weekly one ends.

### Restart the gateway on the connection and not on the process

The restart due after an exit skipped on `IsRunning()`, which answers whether the process is alive when the
question is whether the brokerage is connected. The gateway left up but unauthenticated by a failed weekly
restart answered yes, so the restart was skipped and the deployment sat disconnected.

A gateway that is up but takes no connection is now stopped, and the exit event starts it from zero, which is
what asks for the 2FA confirmation it never got. Once per outage: the second time the connection is down for a
reason a restart does not fix and the heart beat has to be free to report it. The weekly restart had the other
half of the same defect, starting the gateway and never connecting to it.

### Skip the weekly restart on having authenticated, not on having exited

It skipped when the gateway had exited earlier that day, on the grounds that it would have been restarted
automatically, but a gateway that exits comes back on the session token and asks for nothing. For a weekly
restart configured after IB's nightly window this was every Sunday: the token expiry exit at 23:45 made the 23:54
check skip and reschedule a week out.

It now tracks when the gateway last logged in from zero and skips only on that. Day granularity is deliberate: a
login earlier the same Sunday still skips that day, which the heart beat now reports rather than hiding, and an
extra confirmation at the time the user chose is the cheap direction of the trade.

### Requires

QuantConnect/IBAutomater#108 and a package bump. Without it the gateway can still be alive but unauthenticated
when `Exited` is reported, so the restart above finds it running and the weekly login does not happen — reported
and terminated rather than silent, but not recovered.

### Tests

**Unit** — `InteractiveBrokersBrokerageConnectionTests`: a lost connection with nothing accounting for it is a
failed beat; an expected one is not; a restart accounts for its disconnection until it finishes, including
overlapping restarts; `Disconnect` is raised once per disconnection and re-armed by a reconnection but not by a
gateway exit; the restart action follows the connection and not the process; the weekly restart runs until the
gateway has authenticated today; an order refused while disconnected carries the reason.

**Live** — `InteractiveBrokersBrokerageDisconnectionLiveTests`, `[Explicit]`, against a real gateway and IB paper
account. Kills the gateway process, which resets the API socket without delivering a 1100, and holds it down so
the scheduled restart cannot mask the outcome. Against the code before this change it failed the way the ticket
describes, the heart beat noticing seven times over fifteen minutes and telling nobody; with it the restart wait
is waited out quietly and only once nothing accounts for the loss does it escalate and report.

Known limitation: disposing the brokerage after the gateway has been killed out from under IBAutomater can block,
so teardown is bounded and logs when it exceeds it. That is a property of killing the process externally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
