### PR TITLE
Invalidate orders whose cancellation is answered with error 10147

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageHandleErrorTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageHandleErrorTests.cs
@@ -117,6 +117,51 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.AreEqual(1, messages.Count(m => m.Code == errorCode.ToStringInvariant() && m.Type == BrokerageMessageType.Error));
         }
 
+        // IB answers a cancellation it cannot honor with one of two sibling codes: 10147 ("OrderId <id> that
+        // needs to be cancelled is not found.") when the id is not in its open order book at all, and 10148
+        // ("...can not be cancelled, state: <state>") when it is but is already in a terminal state. Both
+        // answer the CancelOrder request within milliseconds and both leave nothing left to wait for, so both
+        // must release the thread parked in CancelOrder and invalidate the order. Only 10148 did: a 10147 was
+        // merely surfaced as a warning, so the wait expired 'ib-response-timeout' later and stopped the
+        // algorithm with 'Timeout waiting for brokerage response'.
+        // See https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/issues/93
+        [TestCase(10147, "OrderId 141 that needs to be cancelled is not found.")]
+        [TestCase(10148, "OrderId 141 that needs to be cancelled can not be cancelled, state: Cancelled.")]
+        public void HandleErrorCancellationRejectionInvalidatesOrderAndReleasesPendingResponse(int errorCode, string errorMessage)
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            const int ibOrderId = 141;
+
+            var orderProvider = new OrderProvider();
+            var order = new MarketOrder(Symbols.SPY, 1, DateTime.UtcNow);
+            order.BrokerId.Add(ibOrderId.ToStringInvariant());
+            orderProvider.Add(order);
+            SetPrivateFieldValue(brokerage, "_orderProvider", orderProvider);
+
+            using var pendingResponseEvent = new ManualResetEventSlim(false);
+            var pendingOrderResponses = (IDictionary)GetPrivateFieldValue(brokerage, "_pendingOrderResponse");
+            pendingOrderResponses[ibOrderId] = pendingResponseEvent;
+            SeedRequestInformation(brokerage, ibOrderId, "CancelOrder", Symbols.SPY);
+
+            List<BrokerageMessageEvent> messages = [];
+            List<OrderEvent> orderEvents = [];
+            brokerage.Message += (_, message) => messages.Add(message);
+            brokerage.OrdersStatusChanged += (_, events) => orderEvents.AddRange(events);
+
+            brokerage.HandleError(this, new IB.ErrorEventArgs(
+                id: ibOrderId,
+                time: 0,
+                code: errorCode,
+                message: errorMessage));
+
+            Assert.IsTrue(pendingResponseEvent.IsSet, "the thread waiting in CancelOrder was not released");
+            Assert.IsFalse(pendingOrderResponses.Contains(ibOrderId));
+            Assert.AreEqual(1, orderEvents.Count(e => e.OrderId == order.Id && e.Status == OrderStatus.Invalid));
+            StringAssert.StartsWith($"{errorCode} - {errorMessage}", orderEvents.Single().Message);
+            // both are filtered codes: the rejection reaches the user as the order event above, not as a message
+            Assert.IsEmpty(messages.Where(m => m.Code == errorCode.ToStringInvariant()));
+        }
+
         // the 200 message is deduped per symbol when 'IgnoreUnknownAssetHoldings' is enabled (the default), for
         // instance the market data subscription of a delisted symbol is rejected with a 200 before any order for
         // it is placed. That dedup must not skip the order invalidation: it left the pending order response
@@ -185,6 +230,9 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         [TestCase(201, "Subscription", true, TestName = "HandleError_Code201_OnNonOrderRequest_StillInvalidates")]
         [TestCase(10008, "History", true, TestName = "HandleError_Code10008_OnHistoryRequest_StillInvalidates")]
         [TestCase(460, null, true, TestName = "HandleError_Code460_WithoutRequestInformation_Invalidates")]
+        // the cancellation of an order whose id was assigned in a previous session, the case the gateway
+        // auto-restart creates, is answered with a 10147 for a request we may no longer be tracking
+        [TestCase(10147, null, true, TestName = "HandleError_Code10147_WithoutRequestInformation_Invalidates")]
         public void HandleErrorInvalidatesError200OnlyWhenItAnswersAnOrderRequest(int errorCode, string requestType, bool expectedInvalidation)
         {
             const int requestId = 7;

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -5848,6 +5848,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private static readonly HashSet<int> InvalidatingCodes = new HashSet<int>
         {
             104, // Can't modify a filled order
+            10147, // OrderId <OrderId> that needs to be cancelled is not found.
             10148, // OrderId <OrderId> that needs to be cancelled can not be cancelled, state:
             460, // No trading permissions
             105, 106, 107, 109, 110, 111, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 129, 131, 132, 133, 134, 135, 136, 137, 140, 141, 146, 147, 148, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 163, 167, 168, 201,312,313,314,315,325,328,329,334,335,336,337,338,339,340,341,342,343,345,347,348,349,350,352,353,355,356,358,359,360,361,362,363,364,367,368,369,370,371,372,373,374,375,376,377,378,379,380,382,383,387,388,389,390,391,392,393,394,395,396,397,398,400,401,402,403,405,406,407,408,409,410,411,412,413,417,418,419,421,423,424,427,428,429,433,434,435,436,437,439,440,441,442,443,444,445,446,447,448,449,463,10002,10006,10007,10008,10009,10010,10011,10012,10014,10020,10058,2102
@@ -5858,6 +5859,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             // 'Request Account Data Sending Error' can happen while connecting sometimes let's ignore it else it bubbles up to the user even if we connected successfully later
             542,
+            10147, // we are going to handle it as an order event
             10148, // we are going to handle it as an order event
             1100, 1101, 1102, 2103, 2104, 2105, 2106, 2107, 2108, 2119, 2157, 2158, IB.CompetingLiveSessionMarketDataErrorHandler.ErrorCode
         };


### PR DESCRIPTION
#### Description

IB answers a cancellation it cannot honor with one of two sibling codes:

- **10148** `OrderId <id> that needs to be cancelled can not be cancelled, state: <state>` — the order is in IB's book but already terminal.
- **10147** `OrderId <id> that needs to be cancelled is not found.` — the id is not in IB's book at all.

Both answer the `CancelOrder` request within milliseconds and both leave nothing left to wait for, but only 10148 was treated as an order event. 10147 was merely surfaced as a warning, so the thread parked in `CancelOrder` on `_pendingOrderResponse` kept waiting until `ib-response-timeout` expired and stopped the algorithm with `Timeout waiting for brokerage response` — five minutes after IB had already answered.

This handles 10147 exactly like 10148: added to `InvalidatingCodes` so the order is invalidated and the waiting thread released right away, and to `FilteredCodes` so the rejection reaches the user as that order event rather than as a duplicate warning message.

Related to #93. Distinct from #245, which covered errors 200 and 460 answering a *placement*; this is the same failure shape on a *cancellation*.

#### Evidence

Reviewing seven live syslogs (LEAN 17649–17942, all predating #245), **25 of 27** `Timeout waiting for brokerage response` errors were preceded by a 10147 that arrived within milliseconds and was dropped. Neither error 200 nor 460 appears in any of them, so #245 would not have prevented a single one.

```
15:10:01.0029  HandleError(): RequestId: 141 ErrorCode: 10147 - OrderId 141 that needs to be
               cancelled is not found.. Origin: [Id=141] CancelOrder: OrderId: 214 ...
15:15:01.0017  ERROR:: Timeout waiting for brokerage response for brokerage order id 141 lean id 214
```

Exactly 300.0 s apart. In the same log, the ten 10148s all reached `HandleError.InvalidateOrder()` and released immediately — the contrast that motivates this change.

Two situations produce a 10147, both observed:

1. **Several Lean orders sharing one IB order id** (combo orders). `CancelOrder` loops over `order.BrokerId` and waits per id, so once the first cancellation of the id succeeds, the following ones find it gone.
2. **An order id assigned in a previous session.** In one deployment, 18 orders placed at 13:15 were cancelled the next morning at 11:40 and every one drew a 10147 — all their ids sat below the `nextValidId` of 436 that the gateway's 23:45 auto-restart had established overnight. This is the aftermath of #242, not the race #242 describes: the cancellations went out twelve hours later on a healthy connection, so the submission gate proposed there would not catch them.

#### Note on ambiguity

#242 deliberately declines to release pending responses on `HandleConnectionClosed`, because in-flight requests are genuinely ambiguous there. That concern does not apply here: with a 10147 IB has told us explicitly that the order is not in its book, so releasing the wait is unambiguous.

#### Requires Updates To Lean

- [ ] Yes
- [x] No

#### Tests

`HandleErrorCancellationRejectionInvalidatesOrderAndReleasesPendingResponse` covers 10147 and 10148 side by side, asserting the pending response is released, the order is invalidated with the rejection message, and no duplicate brokerage message is emitted. A `10147` case was also added to `HandleErrorInvalidatesError200OnlyWhenItAnswersAnOrderRequest` for the untracked-request path the stale-id scenario produces.

Verified the new cases fail on master and pass with the change: reverting only the source edit fails exactly the two 10147 cases while both 10148 cases keep passing. Full fixture: 17/17 passing.

#### Checklist

- [x] I have completely filled out this template
- [x] I have confirmed that this PR does not break any existing tests