### PR TITLE
Bump IBAutomater to 2.0.92 for the FA warning click fix

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
+++ b/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
 	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
 	  <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
-	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.91">
+	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.92">
 		  <!--
 		  Content files of dependencies are excluded by default.
 		  This allows content files to be available in project where nuget will be consumed.


### PR DESCRIPTION
Brings in [QuantConnect/IBAutomater#110](https://github.com/QuantConnect/IBAutomater/pull/110), the fix for the Financial Advisor group orders lost to the "Financial Advisor Warning" dialog (IBAutomater#109, this repo's #93).

The gateway opens one modal warning dialog per order and, when a batch is placed at once, the dialogs stack within milliseconds. IBAutomater clicked `[Yes]` synchronously inside the `WINDOW_OPENED` dispatch — while the dialog was still inside its `setVisible(true)` show sequence — so some clicks never closed their dialog and the flagged orders were never transmitted: no `orderStatus`, no `execDetails`, no error, and LEAN killed the algorithm five minutes later on `ib-response-timeout`. 2.0.92 defers the click off that dispatch, retries it up to five times if the dialog stays open, and stops reporting a hidden-but-not-yet-disposed dialog as still open.

## Verification

Beyond the harness testing in IBAutomater#110, the A/B was re-run end to end through this brokerage against IB paper with the real gateway JVM: a driver algorithm placed 10 asynchronous market orders for ETFs (SPY QQQ IWM DIA EFA EEM GLD TLT XLF XLE) and a test javaagent popped one fake warning dialog per order, plus a manual 20-dialog burst — 30 stacked dialogs per run.

| 30-dialog stacked burst | 2.0.91 | 2.0.92 |
|---|---|---|
| dialogs closed, all `[Yes]` confirmed | 30 / 30 | 30 / 30 |
| false `still open ... will not be transmitted` errors | **7–8** | **0** |
| orders reaching `Submitted` | 10 / 10 | 10 / 10 |
| retries fired (`attempt 2..5/5`) | n/a | 0 |

Two caveats on what this run does and does not show. The retry never fired — stock Swing under the real gateway EDT never dropped a click — so it stays untested insurance, and only live FA-account logs will show how often it engages. The `isVisible()` half of the fix was likewise not the discriminator here: the deferred click alone made every dialog fully disposed before the verification probe ran, so the hidden-but-not-disposed state never arose live. The harness in IBAutomater#110 is what pins that half down.

Worth knowing when reading future user logs: LEAN's `Log.Trace` drops a message identical to the one immediately before it, and 2.0.92's click lines are byte-identical and now consecutive. A stacked burst of 30 clicks showed as 3 lines in the LEAN log while the gateway's own `IBAutomater.log` had all 30 — so grepping a syslog for `(attempt N/5)` undercounts.

Note: NuGet package 2.0.92 publishes when the IBAutomater release goes out — this PR will not build until then.

Related to #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
