### PR TITLE
Fail when the weekly restart time is set after 23:30 UTC

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerageFactory.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerageFactory.cs
@@ -94,6 +94,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 !string.IsNullOrEmpty(weeklyRestartUtcTimeStr))
             {
                 weeklyRestartUtcTime = TimeSpan.Parse(weeklyRestartUtcTimeStr);
+                // leaves room for the check 5 minutes earlier and a login with 2FA retries before 23:45 UTC
+                var maxWeeklyRestartUtcTime = new TimeSpan(23, 30, 0);
+                if (weeklyRestartUtcTime > maxWeeklyRestartUtcTime)
+                {
+                    throw new Exception($"The requested weekly restart time {weeklyRestartUtcTime:hh\\:mm} UTC is too close to the IB Gateway daily restart at 23:45 UTC and the weekly 2FA login would be skipped. " +
+                        $"Please choose any time up to {maxWeeklyRestartUtcTime:hh\\:mm} UTC.");
+                }
             }
 
             if (errors.Count != 0)


### PR DESCRIPTION
The deterministic trigger of #246: a weekly restart configured after IB's nightly window (the reported deployment used 23:59:00) is checked five minutes before the configured time — after the Sunday token-expiry exit has already stamped a same-day exit — so the check skips as already-restarted and the weekly 2FA login is silently deferred a week, every Sunday.

This rejects the configuration at startup: any `ib-weekly-restart-utc-time` later than 23:30 UTC throws before anything is created, with the valid range in the message — a warning could scroll by unread, and this misconfiguration costs the weekly re-authentication. 23:30 leaves room for the check (5 minutes earlier) plus a login with 2FA retries (~10 minutes worst case) to complete before the daily restart at 23:45 UTC — the same proven geometry the defaults live on (code default 16:00 New York, platform default 22:00 UTC).

Note: deployments already configured with a later time will fail on their next start until the setting is updated — deliberate, so the fix cannot be silently ignored.

Validated live against a real gateway with the schedule compressed to minutes: the failing geometry reproduces on demand on master (same-day exit → weekly check skips → no 2FA, no Disconnect ever raised), and the safe geometry runs clean. Timeline details in #250.

#247 / #250 remain the deeper fixes for the non-deterministic failure class (heartbeat watchdog, restart keyed on the connection, skip keyed on login): this PR removes the known trigger with a config guard and stands alone either way.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)