### PR TITLE
Revert the IBAutomater 2.0.92 bump

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
+++ b/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
 	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
 	  <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
-	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.92">
+	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.91">
 		  <!--
 		  Content files of dependencies are excluded by default.
 		  This allows content files to be available in project where nuget will be consumed.


### PR DESCRIPTION
Reverts 6518aa535a449f7b4b053720484604967efd0ebc (#251), putting the `QuantConnect.IBAutomater` reference back to 2.0.91.

Now that #93 is fixed in the brokerage by #252, 2.0.92 has nothing left to do and carries two defects. The full argument is in the [comment on #252](https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/252#issuecomment-5210457863); the short version:

**It never fixed #93.** A/B on a paper advisor account, same 10-order burst, fresh settings store:

| jar | dialogs | `[Yes]` clicks | submitted | timed out |
|---|---|---|---|---|
| pre-#110 | 8 | 8 | 5 / 10 | 5 |
| 2.0.92 | 7 | 2 | 5 / 10 | 5 |

Orders submitted tracks the **dialog count**, not the click count — the dialog is fatal to its own order however well it is dismissed. #252 removes the stacking instead, so exactly one dialog is ever raised.

**Two of its constructs are wrong against the real dialog.** The harness behind QuantConnect/IBAutomater#110 built a fresh `JOptionPane` per order; the gateway actually serves every warning from one reused window (`Financial Advisor Warning` / `IBKR Gateway`, 7 `WINDOW_OPENED` against 12 `WINDOW_CLOSED` on the same instance). Against it the `isDisplayable() || isVisible()` probe reads `Displayable: [true] - Visible: [false]` — a normal in-flight state — as dismissed and **skips the click** (7 dialogs, 2 clicks), and the reentrancy guard de-duplicates on a `Window` instance shared by every warning.

**It silences the triage marker.** Pre-#110 logged 3 × `still open ... the order will not be transmitted`; 2.0.92 logs none, so the orders die with no IBAutomater signal at all.

**Reverting is safe.** #252 was live-verified against all three jars, fresh settings store each time, and order delivery is identical:

| IBAutomater jar | dialogs | `[Yes]` clicks | submitted | timed out |
|---|---|---|---|---|
| pre-#110 build | 1 | 1 | **10 / 10** | 0 |
| 2.0.91 (this PR) | 1 | 1 | **10 / 10** | 0 |
| 2.0.92 | 1 | 1 | **10 / 10** | 0 |

Worth keeping from #110 as a separate, much smaller IBAutomater change if wanted: `doClick(0)` instead of `doClick()` (drops a 68 ms EDT sleep per dialog), and a diagnostic that fires when a confirmation genuinely goes unanswered, with a discriminator in the message so it survives Lean's `Log.Trace` duplicate-line suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
