### PR TITLE
Downgrade the cancellation response timeout to a warning

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -541,7 +541,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                     if (!eventSlim.Wait(_responseTimeout))
                     {
-                        OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "NoBrokerageResponse", $"Timeout waiting for brokerage response for brokerage order id {orderId} lean id {order.Id}"));
+                        if (_pendingOrderResponse.TryRemove(orderId, out _))
+                        {
+                            eventSlim.DisposeSafely();
+
+                            // IB holds the ack when it cannot act on the cancellation yet (order queued outside
+                            // regular trading hours, exchange session break): warn and carry on, the ack arrives on its own
+                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NoBrokerageResponse",
+                                $"Timeout waiting for brokerage response for cancellation of brokerage order id {orderId} lean id {order.Id}"));
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## Description

Surfaces the `CancelOrder` response timeout as a Warning instead of a fatal Error. This is the cancellation slice of #240, re-cut minimally.

IB does not acknowledge a cancellation it cannot act on yet:

- Cancels of orders queued outside regular trading hours are only answered when the market opens. In the #93 syslog analysis, acks arrived 1–2 seconds *after* the 5-minute timeout had already stopped the algorithm ([failure mode 2](https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/issues/93#issuecomment-4973816494)).
- The same holds around exchange session breaks: on 2026-08-07 (live, `L-17359e…`) a CME FX option cancel sent at exactly 21:00 UTC — the CME daily maintenance break — was never answered, and the deployment was stopped five minutes later for a cancellation IB simply couldn't confirm yet.

There is nothing to recover here: the cancel request was delivered, the confirmation arrives on its own through the normal handlers whether or not anyone is waiting (the canceled order event is only ever emitted from that confirmation), and codes answering a cancellation that cannot succeed (10147/10148, #248) already invalidate the order and release the wait. Stopping the whole algorithm for an ack that is merely late is strictly worse than carrying on.

The pending response entry is removed under `TryRemove` so a response racing in exactly at the deadline wins silently, matching the removal semantics of the response handlers; the event is only disposed on the path that still owns it. The placement-timeout path is intentionally untouched — an unanswered placement is genuinely ambiguous and is tracked separately (#242 and the re-sync proposed in #240).

No unit test is included because the timeout branch is only reachable with a connected client and the wait uses the static `_responseTimeout` bound from config at type initialization; the existing `HandleError` release-path tests (10147/10148, 200/460) cover the paths that answer the wait.

## Related Issue

#93, #242

## Motivation and Context

A single unanswered cancellation ack — routinely late by IB design around market opens and session breaks — currently kills the whole live deployment.

## Requires Documentation Change

No.

## How Has This Been Tested?

Build passes; existing cancellation release-path unit tests unaffected. Behavior change verified by inspection against the 2026-08-07 syslog timeline (the deployment would have carried on and received the ack after the session break).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
