### PR TITLE
Explain response timeouts raced by a gateway restart

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -160,6 +160,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         // tracks pending brokerage order responses. In some cases we've seen orders been placed and they never get through to IB
         private readonly ConcurrentDictionary<int, ManualResetEventSlim> _pendingOrderResponse = new();
 
+        // time of the last detected gateway restart, to explain response timeouts of requests the restart raced
+        private DateTime _lastGatewayRestartTimeUtc;
+
         // On a Financial Advisor account IBGateway confirms the first order of a deployment with a warning
         // dialog and silently drops every other order that reaches it while that dialog is unanswered,
         // so the first order goes alone
@@ -1587,6 +1590,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             var isFirstFinancialAdvisorOrder = WaitForFinancialAdvisorFirstOrder();
 
+            var requestTimeUtc = DateTime.UtcNow;
             int ibOrderId;
             ManualResetEventSlim orderSubmittedEvent = null;
 
@@ -1671,7 +1675,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         }
                         else
                         {
-                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "NoBrokerageResponse", $"Timeout waiting for brokerage response for brokerage order id {ibOrderId} lean id {order.Id}"));
+                            var reason = $"Timeout waiting for brokerage response for brokerage order id {ibOrderId} lean id {order.Id}";
+                            if (_lastGatewayRestartTimeUtc >= requestTimeUtc || IsRestartInProgress())
+                            {
+                                reason += ". An IB Gateway restart overlapped the request, which likely never reached IB. " +
+                                    "Consider avoiding order requests around the gateway's scheduled restart time.";
+                            }
+                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "NoBrokerageResponse", reason));
                         }
                     }
                     else
@@ -5555,6 +5565,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private void OnIbAutomaterRestarted(object sender, EventArgs e)
         {
             Log.Trace("InteractiveBrokersBrokerage.OnIbAutomaterRestarted()");
+
+            _lastGatewayRestartTimeUtc = DateTime.UtcNow;
 
             _stateManager.Reset();
             StopGatewayRestartTask();


### PR DESCRIPTION
## Description

When the order-placement response timeout fires after an IB Gateway restart raced the request, the `NoBrokerageResponse` error now explains the cause and how to avoid it, instead of the bare "Timeout waiting for brokerage response" that gives the user nothing to act on:

> Timeout waiting for brokerage response for brokerage order id 38100 lean id 7601. An IB Gateway restart overlapped the request, which likely never reached IB. Consider avoiding order requests around the gateway's scheduled restart time.

Orders written to the socket in the same second the gateway's scheduled daily auto-restart tears the session down are lost — the socket dies milliseconds later and no response ever arrives (#242, observed live on 2026-07-21 and 2026-08-07). The restart defaults to 11:45 PM gateway-local time, so any strategy trading around that minute eventually hits the race, and the user can sidestep it entirely by not submitting orders at that time — once they know that's what is happening.

Implementation: `OnIbAutomaterRestarted` (which fires for every restart flavor — daily auto-restart, weekly, error-triggered) records the restart time, and the timeout branch appends the explanation when that time falls inside the wait. A point-in-time check alone cannot catch this — by the time the timeout fires, the gateway restarted and reconnected minutes earlier (2026-08-07: placement 23:45:00, reconnect complete 23:46:24, timeout 23:50:00). `IsRestartInProgress()` is still consulted for the case where an error-triggered restart is armed but has not executed yet.

Severity is unchanged, and no gating is introduced: preventing submissions during the announced restart window remains tracked by #242 — this only makes the failure actionable when it happens.

## Related Issue

#242, #93

## Motivation and Context

The bare timeout message after the 23:45 race leaves users redeploying blindly into the same failure; naming the restart as the cause lets them fix it on their side by moving order activity away from the restart minute.

## Requires Documentation Change

No.

## How Has This Been Tested?

Build passes; existing tests unaffected. The message path was verified by inspection against the 2026-08-07 syslog timeline: the restart was detected at 23:46:19, inside the 23:45:00→23:50:00 wait, so the explanation would have been appended to all four timeouts.

## Types of changes

- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
