### PR TITLE
Add cryptocurrency support

### DIFF
--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageDataQueueHandlerTest.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageDataQueueHandlerTest.cs
@@ -16,8 +16,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using IBApi;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Brokerages.InteractiveBrokers;
@@ -268,6 +270,152 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             cancelationToken.Dispose();
 
             Assert.IsTrue(tickers.Any(x => symbolsWithData.Any(symbol => symbol.Value == x)));
+        }
+
+        /// <summary>
+        /// Resolves every candidate cryptocurrency against IB and reports the trading parameters it
+        /// answers with, so the symbol properties database can be filled from measured values.
+        /// IB does not enumerate its crypto universe, so the candidates have to be probed one by one.
+        /// </summary>
+        [Test]
+        public void ProbesCryptoUniverseParameters()
+        {
+            Thread.Sleep(2000);
+
+            // IBKR's published list plus other coins commonly offered, IB rejects the ones it does not have
+            var candidates = new[]
+            {
+                "AAVE", "ADA", "ALGO", "APE", "APT", "ARB", "ATOM", "AVAX", "AXS", "BAT",
+                "BCH", "BNB", "BTC", "CANTON", "CC", "COMP", "CRV", "DOGE", "DOT", "ENA",
+                "ENJ", "ETC", "ETH", "FIL", "GRT", "HBAR", "ICP", "IMX", "INJ", "JUP",
+                "LDO", "LINK", "LTC", "MANA", "MATIC", "MKR", "MON", "NEAR", "ONDO", "OP",
+                "PAXG", "PEPE", "RNDR", "SAND", "SEI", "SHIB", "SOL", "STX", "SUI", "SUSHI",
+                "TIA", "TON", "TRX", "UNI", "VET", "WIF", "XLM", "XPL", "XRP", "XTZ", "YFI"
+            };
+
+            using var ib = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(), new SecurityProvider());
+            ib.Connect();
+
+            List<string> resolved = [];
+            List<string> missing = [];
+
+            foreach (var baseCurrency in candidates)
+            {
+                var contract = new Contract
+                {
+                    Symbol = baseCurrency,
+                    SecType = "CRYPTO",
+                    Exchange = "PAXOS",
+                    Currency = Currencies.USD
+                };
+
+                ContractDetails details = null;
+                try
+                {
+                    details = ib.GetContractDetails(contract, baseCurrency + Currencies.USD, failIfNotFound: false);
+                }
+                catch (Exception exception)
+                {
+                    QuantConnect.Logging.Log.Trace($"CryptoUniverse: {baseCurrency} lookup failed: {exception.Message}");
+                }
+
+                if (details == null)
+                {
+                    missing.Add(baseCurrency);
+                    continue;
+                }
+
+                // ready to paste into the symbol properties database
+                resolved.Add($"interactivebrokers,{baseCurrency}{Currencies.USD},crypto,{details.LongName}," +
+                    $"{Currencies.USD},1,{details.MinTick},{details.SizeIncrement},{baseCurrency},{details.MinSize}");
+            }
+
+            QuantConnect.Logging.Log.Trace($"CryptoUniverse: resolved {resolved.Count}, missing {missing.Count} [{string.Join(",", missing)}]");
+            foreach (var row in resolved)
+            {
+                QuantConnect.Logging.Log.Trace("CryptoUniverseRow: " + row);
+            }
+        }
+
+        [Test]
+        public void CanSubscribeToCrypto()
+        {
+            // one gateway session for every pair, connecting is expensive
+            string[] tickers = ["BTCUSD", "ETHUSD", "BTCEUR", "ETHBTC"];
+
+            // Wait a bit to make sure previous tests already disconnected from IB
+            Thread.Sleep(2000);
+
+            using var ib = new InteractiveBrokersBrokerage(new QCAlgorithm(), new OrderProvider(), new SecurityProvider());
+
+            List<string> brokerageMessages = [];
+            ib.Message += (_, message) =>
+            {
+                lock (brokerageMessages)
+                {
+                    brokerageMessages.Add($"{message.Type} {message.Code}: {message.Message}");
+                }
+            };
+            ib.Connect();
+
+            var createContract = typeof(InteractiveBrokersBrokerage)
+                .GetMethod("CreateContract", BindingFlags.NonPublic | BindingFlags.Instance);
+            List<string> resolvedTickers = [];
+            List<string> tickersWithData = [];
+
+            foreach (var ticker in tickers)
+            {
+                var symbol = Symbol.Create(ticker, SecurityType.Crypto, Market.Coinbase);
+
+                // private, but it is the conversion under test
+                var contract = (Contract)createContract.Invoke(ib, [symbol, false, null, null]);
+                QuantConnect.Logging.Log.Trace($"CryptoProbe({ticker}): contract {InteractiveBrokersBrokerage.GetContractDescription(contract)}");
+
+                var details = ib.GetContractDetails(contract, symbol.Value, failIfNotFound: false);
+                if (details == null)
+                {
+                    QuantConnect.Logging.Log.Trace($"CryptoProbe({ticker}): NO CONTRACT");
+                    continue;
+                }
+
+                resolvedTickers.Add(ticker);
+                QuantConnect.Logging.Log.Trace($"CryptoProbe({ticker}): RESOLVED conId={details.Contract.ConId} minTick={details.MinTick} " +
+                    $"tradingClass={details.Contract.TradingClass} validExchanges={details.ValidExchanges} minSize={details.MinSize} sizeIncrement={details.SizeIncrement}");
+
+                var receivedData = false;
+                var loggedTicks = 0;
+                using var cancelationToken = new CancellationTokenSource();
+                ProcessFeed(
+                    ib.Subscribe(GetSubscriptionDataConfig<Tick>(symbol, Resolution.Tick), (s, e) => { receivedData = true; }),
+                    cancelationToken,
+                    (dataPoint) =>
+                    {
+                        if (dataPoint is Tick tick && loggedTicks++ < 3)
+                        {
+                            QuantConnect.Logging.Log.Trace($"CryptoProbe({ticker}): {tick.TickType} {tick.EndTime:O} " +
+                                $"price={tick.Price} bid={tick.BidPrice} ask={tick.AskPrice} quantity={tick.Quantity}");
+                        }
+                    });
+
+                Thread.Sleep(15 * 1000);
+                cancelationToken.Cancel();
+
+                if (receivedData)
+                {
+                    tickersWithData.Add(ticker);
+                }
+                QuantConnect.Logging.Log.Trace($"CryptoProbe({ticker}): receivedData={receivedData}");
+            }
+
+            QuantConnect.Logging.Log.Trace($"CryptoProbe: resolved=[{string.Join(",", resolvedTickers)}] withData=[{string.Join(",", tickersWithData)}]");
+            lock (brokerageMessages)
+            {
+                QuantConnect.Logging.Log.Trace($"CryptoProbe: brokerage messages: {(brokerageMessages.Count == 0 ? "none" : string.Join(" | ", brokerageMessages))}");
+            }
+
+            // the pair every IB crypto enabled account can trade
+            CollectionAssert.Contains(resolvedTickers, "BTCUSD");
+            CollectionAssert.Contains(tickersWithData, "BTCUSD");
         }
 
         private static TestCaseData[] GetCFDAndUnderlyingSubscriptionTestCases()

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageHandleErrorTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersBrokerageHandleErrorTests.cs
@@ -75,6 +75,41 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.AreEqual(expectedMessageCount, messages.Count(m => m.Code == "300"));
         }
 
+        // IB holds a crypto order sent while its venue is closed and says so with 399 just before reporting it
+        // submitted: the order stays open and the user is told. Sequence from a live paper run on 2026-08-29
+        [Test]
+        public void HandleErrorWarnsAboutCryptoOrdersHeldByTheClosedVenue()
+        {
+            using var brokerage = new InteractiveBrokersBrokerage();
+            const int ibOrderId = 46;
+            var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase);
+            var orderProvider = new OrderProvider();
+            var order = new MarketOrder(symbol, 0.00026m, DateTime.UtcNow);
+            orderProvider.Add(order);
+            order.BrokerId.Add(ibOrderId.ToString());
+            SetPrivateFieldValue(brokerage, "_orderProvider", orderProvider);
+            SeedRequestInformation(brokerage, ibOrderId, "PlaceOrder", symbol);
+
+            List<BrokerageMessageEvent> messages = [];
+            List<OrderEvent> orderEvents = [];
+            brokerage.Message += (_, message) => messages.Add(message);
+            brokerage.OrdersStatusChanged += (_, events) => orderEvents.AddRange(events);
+
+            brokerage.HandleError(this, new IB.ErrorEventArgs(
+                id: ibOrderId,
+                time: 0,
+                code: 399,
+                message: "Order Message: BUY 20 USD BTC Crypto (BTC) (BTC.USD)  Warning: your order will not be placed " +
+                    "at the exchange until 2026-08-30 03:00:00 US/Eastern.  To submit the order to the exchange sooner please do so in the Crypto Plus Web-App."));
+
+            Assert.IsEmpty(orderEvents);
+            var held = messages.Single(x => x.Code == "CryptoOrderHeld");
+            Assert.AreEqual(BrokerageMessageType.Warning, held.Type);
+            StringAssert.Contains("brokerage id 46", held.Message);
+            StringAssert.Contains("Sunday 03:00 to Friday 16:00", held.Message);
+            Assert.AreEqual(1, messages.Count(x => x.Code == "399"));
+        }
+
         // errors rejecting an order request must invalidate the order and release the thread waiting
         // for the order response, otherwise the wait times out five minutes later and stops the
         // algorithm with 'Timeout waiting for brokerage response' instead of the actual reason.

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersCryptoOrderTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersCryptoOrderTests.cs
@@ -1,0 +1,286 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.InteractiveBrokers;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Logging;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
+{
+    /// <summary>
+    /// Places real cryptocurrency orders on the paper account, including the "Cryptocurrency order confirmation"
+    /// disclosure IBAutomater has to confirm. Requests no history, so it stays clear of IB's pacing limits.
+    /// </summary>
+    [TestFixture, Explicit("These tests require the IBGateway to be installed.")]
+    public class InteractiveBrokersCryptoOrderTests
+    {
+        private static readonly Symbol _btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase);
+        private static readonly TimeSpan _orderTimeout = TimeSpan.FromSeconds(90);
+
+        /// <summary>
+        /// The buy is sized by cash, so it fills a different quantity than requested and must still close as
+        /// filled. An approximate price is enough, so no crypto data subscription is needed. Sells back what it bought.
+        /// </summary>
+        [Test]
+        public void BuysAtTheMarketForTheCashAmountAndSellsBack()
+        {
+            const decimal referencePrice = 77000m;
+            const decimal cashAmount = 20m;
+
+            var algorithm = new AlgorithmStub();
+            algorithm.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+            var security = algorithm.AddCrypto(_btcusd.Value);
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, referencePrice, referencePrice));
+
+            var orderProvider = new OrderProvider();
+            using var brokerage = new InteractiveBrokersBrokerage(algorithm, orderProvider, new SecurityProvider());
+            var session = Listen(brokerage, "CryptoMarket");
+            brokerage.Connect();
+
+            var buy = new MarketOrder(security.Symbol, cashAmount / referencePrice, DateTime.UtcNow);
+            orderProvider.Add(buy);
+            var buyEvents = PlaceAndWaitForFinalStatus(brokerage, session, buy);
+
+            var fills = buyEvents.Where(x => x.Status is OrderStatus.Filled or OrderStatus.PartiallyFilled).ToList();
+            Assert.IsNotEmpty(fills, $"no fill, statuses [{string.Join(",", buyEvents.Select(x => x.Status))}]");
+            Assert.AreEqual(OrderStatus.Filled, buyEvents.Last().Status, "IB reported the cash spent, the order has to close as filled");
+
+            var filledQuantity = fills.Sum(x => x.FillQuantity);
+            var filledValue = fills.Sum(x => x.FillQuantity * x.FillPrice);
+            Log.Trace($"CryptoMarket: bought {filledQuantity} for {filledValue} USD");
+            Assert.Greater(filledQuantity, 0);
+            // the cash is truncated to whole cents
+            Assert.LessOrEqual(filledValue, cashAmount + 0.01m);
+
+            foreach (var holding in brokerage.GetAccountHoldings().Where(x => x.Symbol.SecurityType == SecurityType.Crypto))
+            {
+                Log.Trace($"CryptoMarket: holding {holding.Symbol.Value} quantity={holding.Quantity} averagePrice={holding.AveragePrice}");
+            }
+
+            var sell = new MarketOrder(security.Symbol, -filledQuantity, DateTime.UtcNow);
+            orderProvider.Add(sell);
+            var sellEvents = PlaceAndWaitForFinalStatus(brokerage, session, sell);
+            Assert.AreEqual(OrderStatus.Filled, sellEvents.LastOrDefault()?.Status, $"statuses [{string.Join(",", sellEvents.Select(x => x.Status))}]");
+            Assert.AreEqual(-filledQuantity, sellEvents.Where(x => x.Status is OrderStatus.Filled or OrderStatus.PartiallyFilled).Sum(x => x.FillQuantity));
+        }
+
+        /// <summary>
+        /// Priced just above the market so it fills at the ask: IB cancels a crypto buy limit further than
+        /// 10 dollars or 0.25% from the best ask, so a resting order cannot be used here
+        /// </summary>
+        [Test]
+        public void BuysWithAMarketableLimitOrderAndSellsBack()
+        {
+            const decimal quantity = 0.0002m;
+
+            var algorithm = new AlgorithmStub();
+            algorithm.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+            algorithm.AddCrypto(_btcusd.Value);
+
+            var orderProvider = new OrderProvider();
+            using var brokerage = new InteractiveBrokersBrokerage(algorithm, orderProvider, new SecurityProvider());
+            var session = Listen(brokerage, "CryptoLimit");
+            brokerage.Connect();
+
+            var price = WaitForPrice(brokerage, _btcusd, TimeSpan.FromSeconds(30));
+            Assert.Greater(price, 0, $"no price for {_btcusd.Value}");
+
+            // 0.1% above the reference, inside IB's band and above the ask, rounded to IB's tick
+            var tick = SymbolPropertiesDatabase.FromDataFolder()
+                .GetSymbolProperties(Market.InteractiveBrokers, _btcusd, SecurityType.Crypto, Currencies.USD)
+                .MinimumPriceVariation;
+            var limitPrice = (price * 1.001m).DiscretelyRoundBy(tick, MidpointRounding.ToPositiveInfinity);
+            Log.Trace($"CryptoLimit: price={price}, limit={limitPrice}, tick={tick}");
+
+            var buy = new LimitOrder(_btcusd, quantity, limitPrice, DateTime.UtcNow);
+            orderProvider.Add(buy);
+            var buyEvents = PlaceAndWaitForFinalStatus(brokerage, session, buy);
+            Assert.AreEqual(OrderStatus.Filled, buyEvents.LastOrDefault()?.Status, $"statuses [{string.Join(",", buyEvents.Select(x => x.Status))}]");
+            Assert.AreEqual(quantity, buyEvents.Where(x => x.Status is OrderStatus.Filled or OrderStatus.PartiallyFilled).Sum(x => x.FillQuantity));
+
+            var sell = new MarketOrder(_btcusd, -quantity, DateTime.UtcNow);
+            orderProvider.Add(sell);
+            var sellEvents = PlaceAndWaitForFinalStatus(brokerage, session, sell);
+            Assert.AreEqual(OrderStatus.Filled, sellEvents.LastOrDefault()?.Status, $"statuses [{string.Join(",", sellEvents.Select(x => x.Status))}]");
+        }
+
+        /// <summary>
+        /// Cancels the crypto orders IB still holds, such as a buy queued while the venue was closed
+        /// </summary>
+        [Test]
+        public void CancelsOpenCryptoOrders()
+        {
+            var algorithm = new AlgorithmStub();
+            algorithm.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+            algorithm.AddCrypto(_btcusd.Value);
+
+            var orderProvider = new OrderProvider();
+            using var brokerage = new InteractiveBrokersBrokerage(algorithm, orderProvider, new SecurityProvider());
+            var session = Listen(brokerage, "CryptoCleanup");
+            brokerage.Connect();
+
+            var openOrders = brokerage.GetOpenOrders().Where(x => x.Symbol.SecurityType == SecurityType.Crypto).ToList();
+            Log.Trace($"CryptoCleanup: {openOrders.Count} open crypto orders");
+            foreach (var order in openOrders)
+            {
+                Log.Trace($"CryptoCleanup: cancelling {order.Type} {order.Symbol.Value} quantity={order.Quantity} brokerIds=[{string.Join(",", order.BrokerId)}]");
+                orderProvider.Add(order);
+                Assert.IsTrue(brokerage.CancelOrder(order), "CancelOrder returned false");
+            }
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+            while (DateTime.UtcNow < deadline && session.CanceledCount < openOrders.Count)
+            {
+                Thread.Sleep(250);
+            }
+            // IB does not acknowledge cancels while its crypto venue is closed, run this when it is open
+            Assert.AreEqual(openOrders.Count, session.CanceledCount, "not every open crypto order was cancelled");
+        }
+
+        private sealed class LiveSession
+        {
+            public readonly List<OrderEvent> Events = [];
+            // IB holds crypto orders placed while its venue is closed and says so with warning 399
+            public volatile string VenueClosedMessage;
+
+            public int CanceledCount
+            {
+                get
+                {
+                    lock (Events)
+                    {
+                        return Events.Count(x => x.Status == OrderStatus.Canceled);
+                    }
+                }
+            }
+        }
+
+        private static LiveSession Listen(InteractiveBrokersBrokerage brokerage, string tag)
+        {
+            var session = new LiveSession();
+            brokerage.Message += (_, message) =>
+            {
+                Log.Trace($"{tag}: {message.Type} {message.Code}: {message.Message}");
+                if (message.Code == "399" && message.Message.Contains("will not be placed at the exchange until"))
+                {
+                    session.VenueClosedMessage = message.Message;
+                }
+            };
+            brokerage.OrdersStatusChanged += (_, orderEvents) =>
+            {
+                foreach (var orderEvent in orderEvents)
+                {
+                    Log.Trace($"{tag}: {orderEvent.Status} quantity={orderEvent.FillQuantity} price={orderEvent.FillPrice} " +
+                        $"fee={orderEvent.OrderFee} {orderEvent.Message}");
+                    lock (session.Events)
+                    {
+                        session.Events.Add(orderEvent);
+                    }
+                }
+            };
+
+            return session;
+        }
+
+        /// <summary>
+        /// Places the order and returns its events once one is final or the timeout elapses. An order IB
+        /// holds because its venue is closed is cancelled and the test is inconclusive.
+        /// </summary>
+        private static List<OrderEvent> PlaceAndWaitForFinalStatus(InteractiveBrokersBrokerage brokerage, LiveSession session, Order order)
+        {
+            int first;
+            lock (session.Events)
+            {
+                first = session.Events.Count;
+            }
+
+            Assert.IsTrue(brokerage.PlaceOrder(order), "PlaceOrder returned false");
+
+            var deadline = DateTime.UtcNow + _orderTimeout;
+            while (true)
+            {
+                if (session.VenueClosedMessage != null)
+                {
+                    brokerage.CancelOrder(order);
+                    Thread.Sleep(3000);
+                    Assert.Inconclusive($"IB holds crypto orders until its venue reopens, run this when it is open: {session.VenueClosedMessage}");
+                }
+
+                lock (session.Events)
+                {
+                    var orderEvents = session.Events.Skip(first).ToList();
+                    if (orderEvents.Any(x => x.Status is OrderStatus.Filled or OrderStatus.Invalid or OrderStatus.Canceled) || DateTime.UtcNow >= deadline)
+                    {
+                        return orderEvents;
+                    }
+                }
+                Thread.Sleep(250);
+            }
+        }
+
+        /// <summary>
+        /// Any tick price is taken, and without the crypto data subscription none arrives: the price IB marks
+        /// the account's holding at is the fallback
+        /// </summary>
+        private static decimal WaitForPrice(InteractiveBrokersBrokerage brokerage, Symbol symbol, TimeSpan timeout)
+        {
+            var config = new SubscriptionDataConfig(typeof(Tick), symbol, Resolution.Tick, TimeZones.Utc, TimeZones.Utc, true, false, false);
+            var enumerator = brokerage.Subscribe(config, (_, _) => { });
+            try
+            {
+                var deadline = DateTime.UtcNow + timeout;
+                while (DateTime.UtcNow < deadline)
+                {
+                    if (enumerator.MoveNext() && enumerator.Current is Tick tick)
+                    {
+                        var price = tick.AskPrice > 0 ? tick.AskPrice : tick.Price;
+                        if (price > 0)
+                        {
+                            Log.Trace($"CryptoLimit: {tick.TickType} price={tick.Price} bid={tick.BidPrice} ask={tick.AskPrice}");
+                            return price;
+                        }
+                    }
+                    else
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
+            }
+            finally
+            {
+                brokerage.Unsubscribe(config);
+            }
+
+            var holding = brokerage.GetAccountHoldings().FirstOrDefault(x => x.Symbol.Value == symbol.Value);
+            if (holding != null && holding.MarketPrice > 0)
+            {
+                Log.Trace($"CryptoLimit: no tick received, using the holding's market price {holding.MarketPrice}");
+                return holding.MarketPrice;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersCryptoTests.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage.Tests/InteractiveBrokersCryptoTests.cs
@@ -1,0 +1,286 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using IBApi;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.InteractiveBrokers;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
+using IB = QuantConnect.Brokerages.InteractiveBrokers.Client;
+using Order = QuantConnect.Orders.Order;
+
+namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
+{
+    [TestFixture]
+    public class InteractiveBrokersCryptoTests
+    {
+        // the brokerage model's default crypto market
+        private static readonly Symbol _btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase);
+        private static readonly DateTime _orderTime = new(2024, 1, 3);
+
+        [Test]
+        public void MapsSecurityTypeToTheIBCryptoContract()
+        {
+            Assert.AreEqual(IB.SecurityType.Crypto, InteractiveBrokersBrokerage.ConvertSecurityType(SecurityType.Crypto));
+            Assert.AreEqual(SecurityType.Crypto, InteractiveBrokersBrokerage.ConvertSecurityType(IB.SecurityType.Crypto, "BTC"));
+        }
+
+        [Test]
+        public void RoutesCryptoToPaxos()
+        {
+            Assert.AreEqual("PAXOS", InteractiveBrokersBrokerage.GetSymbolExchange(SecurityType.Crypto, Market.InteractiveBrokers));
+        }
+
+        [TestCase("BTCUSD")]
+        [TestCase("ETHUSD")]
+        public void MapsLeanAndBrokerageSymbols(string ticker)
+        {
+            var mapper = new InteractiveBrokersSymbolMapper(TestGlobals.MapFileProvider);
+            var symbol = Symbol.Create(ticker, SecurityType.Crypto, Market.InteractiveBrokers);
+
+            Assert.AreEqual(ticker, mapper.GetBrokerageSymbol(symbol));
+
+            var leanSymbol = mapper.GetLeanSymbol(ticker, SecurityType.Crypto, Market.InteractiveBrokers);
+            Assert.AreEqual(ticker, leanSymbol.Value);
+            Assert.AreEqual(SecurityType.Crypto, leanSymbol.ID.SecurityType);
+            Assert.AreEqual(Market.InteractiveBrokers, leanSymbol.ID.Market);
+        }
+
+        // IB splits the pair into base currency (contract symbol) and quote currency
+        [TestCase("BTCUSD", "BTC")]
+        [TestCase("ETHUSD", "ETH")]
+        [TestCase("PAXGUSD", "PAXG")]
+        public void CreatesTheCryptoContract(string ticker, string expectedSymbol)
+        {
+            using var brokerage = CreateBrokerage();
+
+            var contract = CreateContract(brokerage, Symbol.Create(ticker, SecurityType.Crypto, Market.InteractiveBrokers));
+
+            Assert.AreEqual(expectedSymbol, contract.Symbol);
+            Assert.AreEqual(Currencies.USD, contract.Currency);
+            Assert.AreEqual(IB.SecurityType.Crypto, contract.SecType);
+            Assert.AreEqual("PAXOS", contract.Exchange);
+        }
+
+        // on the default crypto market, matching the algorithm's securities
+        [Test]
+        public void MapsTheCryptoContractBackToTheLeanSymbol()
+        {
+            using var brokerage = CreateBrokerage();
+
+            var symbol = MapSymbol(brokerage, new Contract
+            {
+                Symbol = "BTC",
+                SecType = IB.SecurityType.Crypto,
+                Currency = Currencies.USD,
+                Exchange = "PAXOS"
+            });
+
+            Assert.AreEqual(_btcusd, symbol);
+        }
+
+        [Test]
+        public void SubscribesToCrypto()
+        {
+            Assert.IsTrue(CanSubscribe(_btcusd));
+        }
+
+        // only the pairs the database lists for IB, which are the ones IB answers a contract for
+        [TestCase("BTCUSD", true)]
+        [TestCase("ETHUSD", true)]
+        [TestCase("SOLUSD", true)]
+        [TestCase("BTCEUR", false)]   // IB quotes crypto against US dollars only
+        [TestCase("ETHBTC", false)]   // no crypto quoted pairs either
+        [TestCase("ZRXUSD", false)]   // a crypto market pair IB does not list
+        public void SubscribesOnlyToListedCryptoPairs(string ticker, bool expected)
+        {
+            Assert.AreEqual(expected, CanSubscribe(Symbol.Create(ticker, SecurityType.Crypto, Market.InteractiveBrokers)));
+        }
+
+        // IB's tick applies whatever market the symbol is on
+        [TestCase("BTCUSD", 80400.30, 80400.25)]
+        [TestCase("ETHUSD", 2515.86, 2515.85)]
+        public void RoundsCryptoPricesToTheBrokerageTick(string ticker, decimal price, decimal expected)
+        {
+            using var brokerage = CreateBrokerage();
+
+            foreach (var market in new[] { Market.InteractiveBrokers, Market.Coinbase })
+            {
+                var symbol = Symbol.Create(ticker, SecurityType.Crypto, market);
+                var contract = CreateContract(brokerage, symbol);
+
+                Assert.AreEqual((double)expected, brokerage.NormalizePriceToBrokerage(price, contract, symbol), $"market {market}");
+            }
+        }
+
+        // the same pair subscribed on the crypto market still routes here
+        [TestCase("BTCUSD", true)]
+        [TestCase("ZRXUSD", false)]
+        public void SubscribesToListedPairsOnAnyMarket(string ticker, bool expected)
+        {
+            Assert.AreEqual(expected, CanSubscribe(Symbol.Create(ticker, SecurityType.Crypto, Market.Coinbase)));
+        }
+
+        // crypto is the only IB security type that trades in fractional units
+        [Test]
+        public void KeepsFractionalQuantitiesOnLimitOrders()
+        {
+            using var brokerage = CreateBrokerage();
+            var order = new LimitOrder(_btcusd, 0.00001234m, 3370m, _orderTime);
+
+            var ibOrder = ConvertOrder(brokerage, order);
+
+            Assert.AreEqual(0.00001234m, ibOrder.TotalQuantity);
+            Assert.AreEqual(IB.ActionSide.Buy, ibOrder.Action);
+            // IB rejects anything but IOC or its five minute expiry with error 201
+            Assert.AreEqual(IB.TimeInForce.Minutes, ibOrder.Tif);
+            // CashQty is left at its unset default, only crypto buy market orders use it
+            Assert.AreEqual(double.MaxValue, ibOrder.CashQty);
+        }
+
+        // IB only accepts crypto market orders as immediate-or-cancel
+        [Test]
+        public void SendsSellMarketOrdersAsImmediateOrCancelWithAQuantity()
+        {
+            using var brokerage = CreateBrokerage();
+            var order = new MarketOrder(_btcusd, -0.5m, _orderTime);
+
+            var ibOrder = ConvertOrder(brokerage, order);
+
+            Assert.AreEqual(IB.TimeInForce.ImmediateOrCancel, ibOrder.Tif);
+            Assert.AreEqual(IB.ActionSide.Sell, ibOrder.Action);
+            Assert.AreEqual(0.5m, ibOrder.TotalQuantity);
+            // sells are sized by quantity, only buys use a cash amount
+            Assert.AreEqual(double.MaxValue, ibOrder.CashQty);
+        }
+
+        // IB sizes crypto buy market orders by the cash amount to spend instead of by quantity
+        [Test]
+        public void SendsBuyMarketOrdersWithACashQuantity()
+        {
+            var algorithm = new AlgorithmStub();
+            algorithm.SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
+            var security = algorithm.AddCrypto("BTCUSD");
+            security.SetMarketPrice(new Tick(_orderTime, security.Symbol, 40000m, 40000m));
+
+            using var brokerage = CreateBrokerage();
+            SetPrivateField(brokerage, "_algorithm", algorithm);
+
+            var ibOrder = ConvertOrder(brokerage, new MarketOrder(security.Symbol, 0.25m, _orderTime));
+
+            Assert.AreEqual(IB.TimeInForce.ImmediateOrCancel, ibOrder.Tif);
+            Assert.AreEqual(0.25 * 40000, ibOrder.CashQty);
+            Assert.AreEqual(0m, ibOrder.TotalQuantity);
+        }
+
+        [Test]
+        public void FailsBuyMarketOrdersWithoutAKnownPrice()
+        {
+            using var brokerage = CreateBrokerage();
+            var order = new MarketOrder(_btcusd, 0.25m, _orderTime);
+
+            var exception = Assert.Throws<TargetInvocationException>(() => ConvertOrder(brokerage, order));
+            Assert.IsInstanceOf<InvalidOperationException>(exception.InnerException);
+            StringAssert.Contains("crypto buy market order", exception.InnerException.Message);
+        }
+
+        [Test]
+        public void ReadsBackFractionalOpenOrderQuantities()
+        {
+            using var brokerage = CreateBrokerage();
+            var contract = CreateContract(brokerage, _btcusd);
+            var ibOrder = new IBApi.Order
+            {
+                OrderId = 1,
+                Action = IB.ActionSide.Buy,
+                TotalQuantity = 0.00001234m,
+                OrderType = IB.OrderType.Limit,
+                LmtPrice = 3370,
+                Tif = IB.TimeInForce.GoodTillCancel
+            };
+
+            var orders = ConvertOrders(brokerage, ibOrder, contract);
+
+            Assert.AreEqual(1, orders.Count);
+            Assert.AreEqual(0.00001234m, orders[0].Quantity);
+            Assert.AreEqual(_btcusd, orders[0].Symbol);
+        }
+
+        /// <summary>
+        /// Seeds the collaborators the conversions need, so no gateway is required
+        /// </summary>
+        private static InteractiveBrokersBrokerage CreateBrokerage()
+        {
+            var brokerage = new InteractiveBrokersBrokerage();
+            SetPrivateField(brokerage, "_symbolMapper", new InteractiveBrokersSymbolMapper(TestGlobals.MapFileProvider));
+            SetPrivateField(brokerage, "_account", "DU123456");
+            // IB reports crypto tick sizes through the contract details, which we can't request offline
+            SetPrivateField(brokerage, "_contractSpecificationService",
+                new IB.ContractSpecificationService((contract, _, _) => new ContractDetails { Contract = contract, MinTick = 0.01 }));
+
+            return brokerage;
+        }
+
+        private static Contract CreateContract(InteractiveBrokersBrokerage brokerage, Symbol symbol)
+        {
+            return (Contract)InvokePrivate(brokerage, "CreateContract", [symbol, false, null, null]);
+        }
+
+        private static Symbol MapSymbol(InteractiveBrokersBrokerage brokerage, Contract contract)
+        {
+            return (Symbol)InvokePrivate(brokerage, "MapSymbol", [contract]);
+        }
+
+        private static IBApi.Order ConvertOrder(InteractiveBrokersBrokerage brokerage, Order order)
+        {
+            var contract = CreateContract(brokerage, order.Symbol);
+            return (IBApi.Order)InvokePrivate(brokerage, "ConvertOrder",
+                [new List<Order> { order }, contract, 1], typeof(List<Order>), typeof(Contract), typeof(int));
+        }
+
+        private static List<Order> ConvertOrders(InteractiveBrokersBrokerage brokerage, IBApi.Order ibOrder, Contract contract)
+        {
+            return (List<Order>)InvokePrivate(brokerage, "ConvertOrders", [ibOrder, contract, new OrderState { Status = "Submitted" }]);
+        }
+
+        private static bool CanSubscribe(Symbol symbol)
+        {
+            return (bool)typeof(InteractiveBrokersBrokerage)
+                .GetMethod("CanSubscribe", BindingFlags.NonPublic | BindingFlags.Static)
+                .Invoke(null, [symbol]);
+        }
+
+        private static object InvokePrivate(InteractiveBrokersBrokerage brokerage, string name, object[] arguments, params Type[] parameterTypes)
+        {
+            var method = parameterTypes.Length > 0
+                ? typeof(InteractiveBrokersBrokerage).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance, parameterTypes)
+                : typeof(InteractiveBrokersBrokerage).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            return method.Invoke(brokerage, arguments);
+        }
+
+        private static void SetPrivateField(InteractiveBrokersBrokerage brokerage, string name, object value)
+        {
+            typeof(InteractiveBrokersBrokerage)
+                .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(brokerage, value);
+        }
+    }
+}

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/InteractiveBrokersClient.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/InteractiveBrokersClient.cs
@@ -392,8 +392,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <param name="averageCost">The average cost of the position.</param>
         public override void positionMulti(int requestId, string account, string modelCode, Contract contract, decimal position, double averageCost)
         {
-            var positionValue = Convert.ToInt32(position);
-            OnUpdatePortfolio(new UpdatePortfolioEventArgs(contract, positionValue, 0, 0, averageCost, 0, 0, account));
+            OnUpdatePortfolio(new UpdatePortfolioEventArgs(contract, position, 0, 0, averageCost, 0, 0, account));
         }
 
         /// <summary>
@@ -452,8 +451,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         public override void updatePortfolio(Contract contract, decimal position, double marketPrice, double marketValue, double averageCost,
             double unrealisedPnl, double realisedPnl, string accountName)
         {
-            var positionValue = Convert.ToInt32(position);
-            OnUpdatePortfolio(new UpdatePortfolioEventArgs(contract, positionValue, marketPrice, marketValue, averageCost, unrealisedPnl, realisedPnl,
+            OnUpdatePortfolio(new UpdatePortfolioEventArgs(contract, position, marketPrice, marketValue, averageCost, unrealisedPnl, realisedPnl,
                 accountName));
         }
 
@@ -482,9 +480,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <param name="mktCapPrice">If an order has been capped, this indicates the current capped price. Requires TWS 967+ and API v973.04+. Python API specifically requires API v973.06+.</param>
         public override void orderStatus(int orderId, string status, decimal filled, decimal remaining, double avgFillPrice, long permId, int parentId, double lastFillPrice, int clientId, string whyHeld, double mktCapPrice)
         {
-            var filledValue = Convert.ToInt32(filled);
-            var remainingValue = Convert.ToInt32(remaining);
-            OnOrderStatus(new OrderStatusEventArgs(orderId, status, filledValue, remainingValue, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld, mktCapPrice));
+            OnOrderStatus(new OrderStatusEventArgs(orderId, status, filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld, mktCapPrice));
         }
 
         /// <summary>

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/OrderStatusEventArgs.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/OrderStatusEventArgs.cs
@@ -35,12 +35,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <summary>
         /// Specifies the number of shares that have been executed.
         /// </summary>
-        public int Filled { get; }
+        public decimal Filled { get; }
 
         /// <summary>
         /// Specifies the number of shares still outstanding.
         /// </summary>
-        public int Remaining { get; }
+        public decimal Remaining { get; }
 
         /// <summary>
         /// The average price of the shares that have been executed.
@@ -87,7 +87,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderStatusEventArgs"/> class
         /// </summary>
-        public OrderStatusEventArgs(int orderId, string status, int filled, int remaining, double averageFillPrice, long permId, int parentId, double lastFillPrice, int clientId, string whyHeld, double mktCapPrice)
+        public OrderStatusEventArgs(int orderId, string status, decimal filled, decimal remaining, double averageFillPrice, long permId, int parentId, double lastFillPrice, int clientId, string whyHeld, double mktCapPrice)
         {
             OrderId = orderId;
             Status = status;

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/SecurityType.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/SecurityType.cs
@@ -81,6 +81,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         public const string ContractForDifference = "CFD";
 
         /// <summary>
+        /// Cryptocurrency
+        /// </summary>
+        public const string Crypto = "CRYPTO";
+
+        /// <summary>
         /// Undefined Security Type
         /// </summary>
         public const string Undefined = "";

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/TimeInForce.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/TimeInForce.cs
@@ -51,6 +51,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         public const string MarketOnOpen = "OPG";
 
         /// <summary>
+        /// Cancels the order if it is not filled within five minutes
+        /// </summary>
+        public const string Minutes = "Minutes";
+
+        /// <summary>
         /// Undefined
         /// </summary>
         public const string Undefined = "";

--- a/QuantConnect.InteractiveBrokersBrokerage/Client/UpdatePortfolioEventArgs.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/Client/UpdatePortfolioEventArgs.cs
@@ -30,10 +30,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         public Contract Contract { get; }
 
         /// <summary>
-        /// The number of positions held.
+        /// The number of positions held. Crypto is held in fractional units.
         /// If the position is 0, it means the position has just cleared.
         /// </summary>
-        public int Position { get; }
+        public decimal Position { get; }
 
         /// <summary>
         /// The unit price of the instrument.
@@ -68,7 +68,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdatePortfolioEventArgs"/> class
         /// </summary>
-        public UpdatePortfolioEventArgs(Contract contract, int position, double marketPrice, double marketValue, double averageCost, double unrealisedPnl, double realisedPnl, string accountName)
+        public UpdatePortfolioEventArgs(Contract contract, decimal position, double marketPrice, double marketValue, double averageCost, double unrealisedPnl, double realisedPnl, string accountName)
         {
             Contract = contract;
             Position = position;

--- a/QuantConnect.InteractiveBrokersBrokerage/HistoricalDataType.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/HistoricalDataType.cs
@@ -26,6 +26,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         public const string Trades = "TRADES";
 
         /// <summary>
+        /// Return aggregated trade data, the only trade data type IB accepts for cryptocurrencies
+        /// </summary>
+        public const string AggTrades = "AGGTRADES";
+
+        /// <summary>
         /// Return the mid point between the bid and ask
         /// </summary>
         public const string Midpoint = "MIDPOINT";

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersBrokerage.cs
@@ -26,6 +26,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.TimeInForces;
 using QuantConnect.Packets;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
 using QuantConnect.Securities.FutureOption;
 using QuantConnect.Securities.Index;
 using QuantConnect.Securities.IndexOption;
@@ -91,6 +92,18 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private static bool _submissionOrdersWarningSent;
         private static bool _openOrderTimeWarningSent;
         private bool _sentFAOrderPropertiesWarning;
+        private bool _cryptoTimeInForceWarningSent;
+
+        // crypto buy market orders are sized by cash, so only IB knows when they are done. Keyed by IB order id
+        private readonly ConcurrentDictionary<int, CashQuantityOrderState> _cashQuantityOrders = [];
+
+        private class CashQuantityOrderState
+        {
+            // what IB reports filled once it marks the order done
+            public decimal? QuantityFilledByIb;
+            // what our fill events have reported so far
+            public decimal QuantityEmitted;
+        }
 
         private readonly HashSet<OrderType> _noSubmissionOrderTypes = new(new[] {
             OrderType.MarketOnOpen,
@@ -223,6 +236,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         };
 
         private static readonly SymbolPropertiesDatabase _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
+
+        // the pairs IB lists with the parameters it reports, keyed by ticker: the traded symbol can be on the crypto market
+        private static readonly Lazy<Dictionary<string, SymbolProperties>> _cryptoSymbolProperties = new(() =>
+            _symbolPropertiesDatabase.GetSymbolPropertiesList(Market.InteractiveBrokers, SecurityType.Crypto)
+                .ToDictionary(entry => entry.Key.Symbol, entry => entry.Value, StringComparer.InvariantCultureIgnoreCase));
 
         /// <summary>
         /// Provides primary exchange data based on LEAN map files.
@@ -1562,6 +1580,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 return;
             }
 
+            if (needsNewId && order.SecurityType == SecurityType.Crypto && order.Type == OrderType.Market
+                && order.Direction == OrderDirection.Buy && !TryGetCryptoMarketBuyPrice(order, out _, out var rejection))
+            {
+                // rejected here so the reason reaches the algorithm
+                OnOrderEvents([ new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero, rejection) { Status = OrderStatus.Invalid } ]);
+                return;
+            }
+
             // MOO/MOC require directed option orders.
             // We resolve non-equity markets in the `CreateContract` method.
             if (exchange == null &&
@@ -1966,11 +1992,18 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <returns>The price normalized to be brokerage expected unit</returns>
         public double NormalizePriceToBrokerage(decimal price, Contract contract, Symbol symbol, OrderType? orderType = null)
         {
-            var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, Currencies.USD);
+            // IB's own parameters, whatever market the symbol is on
+            var symbolProperties = symbol.SecurityType == SecurityType.Crypto
+                && _cryptoSymbolProperties.Value.TryGetValue(symbol.Value, out var cryptoProperties)
+                ? cryptoProperties
+                : _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, Currencies.USD);
 
-            var minTick = 0m;
+            var minTick = symbolProperties.MinimumPriceVariation;
             switch (symbol.SecurityType)
             {
+                case SecurityType.Crypto:
+                    // the database holds the tick IB reports for the pair
+                    break;
                 case SecurityType.IndexOption when orderType is not (OrderType.ComboLimit or OrderType.ComboLegLimit):
                     minTick = IndexOptionSymbolProperties.MinimumPriceVariationForPrice(symbol, price);
                     break;
@@ -2247,6 +2280,17 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 _competingSessionErrorHandler.Value.Handle(DateTime.UtcNow, errorCode, errorMsg);
             }
 
+            if (errorCode == 399
+                && requestInfo?.RequestType == RequestType.PlaceOrder
+                && requestInfo.AssociatedSymbol?.SecurityType == SecurityType.Crypto
+                && errorMsg.Contains("will not be placed at the exchange until", StringComparison.OrdinalIgnoreCase))
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "CryptoOrderHeld",
+                    $"Interactive Brokers routes cryptocurrency orders from Sunday 03:00 to Friday 16:00 New York time only: " +
+                    $"the {requestInfo.AssociatedSymbol.Value} order with brokerage id {requestId} was accepted but is held until the " +
+                    $"venue reopens, and will then be worked at the prices of that moment. Cancel it if that is not intended. IB: {errorMsg}"));
+            }
+
             // error 200 is not an invalidating code: unlike the codes in the collection it answers any request
             // type (e.g. contract details or market data), so it's only an order rejection when we know it is
             // answering an order request
@@ -2408,6 +2452,37 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 if (firstOrder.GroupOrderManager != null && (status == OrderStatus.Filled || status == OrderStatus.Canceled))
                 {
                     _comboOrdersContracts.TryRemove(firstOrder.GroupOrderManager.Id, out _);
+                }
+
+                if (_cashQuantityOrders.TryGetValue(update.OrderId, out var cashQuantityOrder))
+                {
+                    if (status == OrderStatus.Filled)
+                    {
+                        // the cash is spent, the fills close on this quantity
+                        bool fillsAlreadyEmitted;
+                        lock (cashQuantityOrder)
+                        {
+                            cashQuantityOrder.QuantityFilledByIb = update.Filled;
+                            fillsAlreadyEmitted = cashQuantityOrder.QuantityEmitted == update.Filled;
+                        }
+
+                        if (fillsAlreadyEmitted)
+                        {
+                            // the last fill was reported as partial, close the order
+                            _cashQuantityOrders.TryRemove(update.OrderId, out _);
+                            OnOrderEvents(orders.Select(order => new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero, "Interactive Brokers Order Fill Event")
+                            {
+                                Status = OrderStatus.Filled,
+                                FillPrice = NormalizePriceToLean(update.AverageFillPrice, order.Symbol)
+                            }).ToList());
+                        }
+                        return;
+                    }
+
+                    if (status == OrderStatus.Canceled || status == OrderStatus.Invalid)
+                    {
+                        _cashQuantityOrders.TryRemove(update.OrderId, out _);
+                    }
                 }
 
                 if (status == OrderStatus.Filled || status == OrderStatus.PartiallyFilled)
@@ -2740,7 +2815,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 if (executionDetails.Execution.Liquidation == 1)
                 {
-                    var currentQuantityFilled = Convert.ToInt32(executionDetails.Execution.Shares);
+                    var currentQuantityFilled = executionDetails.Execution.Shares;
                     if (executionDetails.Execution.Side == "SLD")
                     {
                         // BOT for bought, SLD for sold
@@ -2863,9 +2938,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 var targetOrderCommissionReport = fillDetails.CommissionReport;
 
                 var absoluteQuantity = targetOrder.AbsoluteQuantity;
-                var currentQuantityFilled = Convert.ToInt32(targetOrderExecutionDetails.Execution.Shares);
-                var totalQuantityFilled = Convert.ToInt32(targetOrderExecutionDetails.Execution.CumQty);
-                var remainingQuantity = Convert.ToInt32(absoluteQuantity - totalQuantityFilled);
+                var currentQuantityFilled = targetOrderExecutionDetails.Execution.Shares;
+                var totalQuantityFilled = targetOrderExecutionDetails.Execution.CumQty;
+                var remainingQuantity = absoluteQuantity - totalQuantityFilled;
                 var price = NormalizePriceToLean(targetOrderExecutionDetails.Execution.Price, targetOrder.Symbol);
                 var orderFee = new OrderFee(new CashAmount(
                     Convert.ToDecimal(targetOrderCommissionReport.CommissionAndFees),
@@ -2873,6 +2948,21 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 // set order status based on remaining quantity
                 var status = remainingQuantity > 0 ? OrderStatus.PartiallyFilled : OrderStatus.Filled;
+                if (_cashQuantityOrders.TryGetValue(targetOrderExecutionDetails.Execution.OrderId, out var cashQuantityOrder))
+                {
+                    // sized by cash, the order is done when IB says so
+                    lock (cashQuantityOrder)
+                    {
+                        cashQuantityOrder.QuantityEmitted = totalQuantityFilled;
+                        status = cashQuantityOrder.QuantityFilledByIb == totalQuantityFilled ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
+                    }
+                    remainingQuantity = 0;
+
+                    if (status == OrderStatus.Filled)
+                    {
+                        _cashQuantityOrders.TryRemove(targetOrderExecutionDetails.Execution.OrderId, out _);
+                    }
+                }
 
                 // mark sells as negative quantities
                 var fillQuantity = targetOrder.Direction == OrderDirection.Buy ? currentQuantityFilled : -currentQuantityFilled;
@@ -3004,7 +3094,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 OrderId = ibOrderId,
                 Account = _account,
                 Action = ConvertOrderDirection(direction),
-                TotalQuantity = (int)Math.Abs(quantity),
+                // already rounded to the lot size, which is 1 for everything but crypto
+                TotalQuantity = Math.Abs(quantity),
                 OrderType = ConvertOrderType(order.Type),
                 AllOrNone = false,
                 Tif = ConvertTimeInForce(order),
@@ -3103,6 +3194,21 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 AddGuaranteedTag(ibOrder, orders.All(x => x.SecurityType == SecurityType.Equity));
             }
 
+            if (order.SecurityType == SecurityType.Crypto)
+            {
+                if (order.Type == OrderType.Market)
+                {
+                    ApplyCryptoMarketOrderProperties(ibOrder, order, direction, quantity);
+                }
+                else if (!_cryptoTimeInForceWarningSent)
+                {
+                    _cryptoTimeInForceWarningSent = true;
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "CryptoTimeInForce",
+                        "Interactive Brokers does not keep cryptocurrency orders working, the requested time in force is " +
+                        "replaced by its five minute expiry and the order is cancelled if it has not filled by then."));
+                }
+            }
+
             // add financial advisor properties
             if (IsFinancialAdvisor)
             {
@@ -3168,11 +3274,66 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             return ibOrder;
         }
 
+        /// <summary>
+        /// Sizes a cryptocurrency buy market order by the cash amount to spend, which is what IB expects
+        /// instead of a quantity. See https://interactivebrokers.github.io/tws-api/cryptocurrency.html
+        /// </summary>
+        private void ApplyCryptoMarketOrderProperties(IBApi.Order ibOrder, Order order, OrderDirection direction, decimal quantity)
+        {
+            if (direction != OrderDirection.Buy)
+            {
+                return;
+            }
+
+            if (!TryGetCryptoMarketBuyPrice(order, out var price, out var reason))
+            {
+                // IBPlaceOrder rejects these before getting here
+                throw new InvalidOperationException($"InteractiveBrokersBrokerage.ConvertOrder(): {reason}");
+            }
+
+            // whole cents, never more than the requested quantity is worth
+            var absoluteQuantity = Math.Abs(quantity);
+            var cashQuantity = Math.Truncate(absoluteQuantity * price * 100m) / 100m;
+            ibOrder.CashQty = (double)cashQuantity;
+            ibOrder.TotalQuantity = 0;
+            _cashQuantityOrders[ibOrder.OrderId] = new CashQuantityOrderState();
+
+            var quoteCurrency = GetSymbolProperties(order.Symbol).QuoteCurrency;
+            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "CryptoCashQuantity",
+                $"Interactive Brokers sizes cryptocurrency buy market orders by the cash amount to spend instead of by quantity: " +
+                $"order {order.Id} for {absoluteQuantity} {order.Symbol.Value} was submitted as {cashQuantity} {quoteCurrency}, " +
+                $"converted at the last known price of {price} {quoteCurrency}. The filled quantity can differ from the requested " +
+                $"one, use a limit order to avoid this."));
+        }
+
+        /// <summary>
+        /// Gets the price a cryptocurrency buy market order is sized with, IB expects the cash amount to spend
+        /// </summary>
+        private bool TryGetCryptoMarketBuyPrice(Order order, out decimal price, out string reason)
+        {
+            price = 0m;
+            reason = null;
+            if (_algorithm != null && _algorithm.Securities.TryGetValue(order.Symbol, out var security))
+            {
+                price = security.Price;
+            }
+
+            if (price > 0)
+            {
+                return true;
+            }
+
+            reason = $"A known price for {order.Symbol.Value} is required to place a crypto buy market order, because IB expects " +
+                "the cash amount to spend instead of the quantity. Use a limit order instead or make sure the security is subscribed and has data.";
+            return false;
+        }
+
         private List<Order> ConvertOrders(IBApi.Order ibOrder, Contract contract, OrderState orderState)
         {
             var result = new List<Order>();
             var quantitySign = ConvertOrderDirection(ibOrder.Action) == OrderDirection.Sell ? -1 : 1;
-            var quantity = Convert.ToInt32(ibOrder.TotalQuantity) * quantitySign;
+            // crypto quantities are fractional
+            var quantity = ibOrder.TotalQuantity * quantitySign;
 
             if (contract.SecType == IB.SecurityType.Bag)
             {
@@ -3419,6 +3580,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 contract.Exchange = "IDEALPRO";
                 contract.Symbol = ibSymbol.Substring(0, 3);
                 contract.Currency = ibSymbol.Substring(3);
+            }
+            else if (symbol.ID.SecurityType == SecurityType.Crypto)
+            {
+                // the base currency is not always 3 characters long
+                Crypto.DecomposeCurrencyPair(symbol, symbolProperties, out var baseCurrency, out _);
+                contract.Symbol = baseCurrency;
             }
             else if (symbol.ID.SecurityType == SecurityType.Cfd)
             {
@@ -3696,6 +3863,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </summary>
         private static string ConvertTimeInForce(Order order)
         {
+            if (order.SecurityType == SecurityType.Crypto)
+            {
+                // anything else is rejected with error 201, Minutes is IB's five minute expiry
+                return order.Type == OrderType.Market
+                    ? IB.TimeInForce.ImmediateOrCancel
+                    : IB.TimeInForce.Minutes;
+            }
+
             if (order.Type == OrderType.MarketOnOpen)
             {
                 return IB.TimeInForce.MarketOnOpen;
@@ -3801,6 +3976,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case SecurityType.Cfd:
                     return IB.SecurityType.ContractForDifference;
 
+                case SecurityType.Crypto:
+                    return IB.SecurityType.Crypto;
+
                 default:
                     throw new ArgumentException($"The {type} security type is not currently supported.");
             }
@@ -3843,6 +4021,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 case IB.SecurityType.ContractForDifference:
                     return SecurityType.Cfd;
+
+                case IB.SecurityType.Crypto:
+                    return SecurityType.Crypto;
 
                 default:
                     throw new NotSupportedException(
@@ -4005,8 +4186,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 var securityType = ConvertSecurityType(contract);
 
                 var ibSymbol = contract.Symbol;
-                if (securityType == SecurityType.Forex)
+                if (securityType == SecurityType.Forex || securityType == SecurityType.Crypto)
                 {
+                    // IB splits the pair into symbol and currency
                     ibSymbol += contract.Currency;
                 }
                 else if (securityType == SecurityType.Cfd)
@@ -4404,7 +4586,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 (securityType == SecurityType.Index && (market == Market.USA || market == Market.EUREX || market == Market.OSE || market == Market.HKFE || market == Market.KRX)) ||
                 (securityType == SecurityType.FutureOption) ||
                 (securityType == SecurityType.Future) ||
-                (securityType == SecurityType.Cfd && market == Market.InteractiveBrokers);
+                (securityType == SecurityType.Cfd && market == Market.InteractiveBrokers) ||
+                (securityType == SecurityType.Crypto && _cryptoSymbolProperties.Value.ContainsKey(symbol.Value));
         }
 
         /// <summary>
@@ -4975,7 +5158,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else
             {
                 // other assets will have TradeBars
-                history = GetHistory(request, contract, startTime, endTime, exchangeTimeZone, resolution, HistoricalDataType.Trades);
+                // TRADES is rejected for crypto with error 10299
+                var tradeDataType = request.Symbol.SecurityType == SecurityType.Crypto
+                    ? HistoricalDataType.AggTrades
+                    : HistoricalDataType.Trades;
+                history = GetHistory(request, contract, startTime, endTime, exchangeTimeZone, resolution, tradeDataType);
             }
 
             return FilterHistory(history, request, startTimeLocal, endTimeLocal, contract);
@@ -5191,6 +5378,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 case SecurityType.Forex:
                     return "IDEALPRO"; // IB's Forex market is always IDEALPRO
+                case SecurityType.Crypto:
+                    return "PAXOS"; // IB executes and custodies cryptocurrencies through Paxos
                 case SecurityType.Option:
                 case SecurityType.IndexOption:
                     // Regular equity options uses default, in this case "Smart"

--- a/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersSymbolMapper.cs
+++ b/QuantConnect.InteractiveBrokersBrokerage/InteractiveBrokersSymbolMapper.cs
@@ -96,7 +96,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 symbol.ID.SecurityType != SecurityType.IndexOption &&
                 symbol.ID.SecurityType != SecurityType.FutureOption &&
                 symbol.ID.SecurityType != SecurityType.Future &&
-                symbol.ID.SecurityType != SecurityType.Cfd)
+                symbol.ID.SecurityType != SecurityType.Cfd &&
+                symbol.ID.SecurityType != SecurityType.Crypto)
             {
                 throw new ArgumentException("Invalid security type: " + symbol.ID.SecurityType);
             }
@@ -138,7 +139,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 securityType != SecurityType.IndexOption &&
                 securityType != SecurityType.Future &&
                 securityType != SecurityType.FutureOption &&
-                securityType != SecurityType.Cfd)
+                securityType != SecurityType.Cfd &&
+                securityType != SecurityType.Crypto)
                 throw new ArgumentException("Invalid security type: " + securityType);
 
             try

--- a/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
+++ b/QuantConnect.InteractiveBrokersBrokerage/QuantConnect.InteractiveBrokersBrokerage.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
 	  <PackageReference Include="QuantConnect.Brokerages" Version="2.5.*" />
 	  <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
-	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.91">
+	  <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.93">
 		  <!--
 		  Content files of dependencies are excluded by default.
 		  This allows content files to be available in project where nuget will be consumed.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository hosts the Interactive Brokers (IB) Brokerage Plugin Integration 
 </picture>
 <p>
 
-IB was founded by Thomas Peterffy in 1993 with the goal to "create technology to provide liquidity on better terms. Compete on price, speed, size, diversity of global products and advanced trading tools". IB provides access to trading Equities, ETFs, Options, Futures, Future Options, Forex, Gold, Warrants, Bonds, and Mutual Funds for clients in over [200 countries and territories](https://www.interactivebrokers.com/en/index.php?f=7021) with no minimum deposit. IB also provides paper trading, a trading platform, and educational services.
+IB was founded by Thomas Peterffy in 1993 with the goal to "create technology to provide liquidity on better terms. Compete on price, speed, size, diversity of global products and advanced trading tools". IB provides access to trading Equities, ETFs, Options, Futures, Future Options, Forex, Cryptocurrencies, Gold, Warrants, Bonds, and Mutual Funds for clients in over [200 countries and territories](https://www.interactivebrokers.com/en/index.php?f=7021) with no minimum deposit. IB also provides paper trading, a trading platform, and educational services.
 
 For more information about the IB brokerage, see the [QuantConnect-IB Integration Page](https://www.quantconnect.com/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers).
 
@@ -145,6 +145,22 @@ The following table describes the order types that IB supports. For specific det
 | `MarketOnCloseOrder` | [Market-on-Close (MOC) Orders](https://www.interactivebrokers.com/en/index.php?f=599) |
 | `ExerciseOption` | [Options Exercise](https://www.interactivebrokers.ca/en/trading/exerciseCloseout.php) |
 
+Cryptocurrencies only support `MarketOrder` and `LimitOrder`, see [Cryptocurrency](https://interactivebrokers.github.io/tws-api/cryptocurrency.html).
+IB accepts crypto market orders as immediate-or-cancel only, and sizes buy market orders by the cash amount to
+spend, which Lean estimates from the last known price, so the filled quantity can differ from the requested one.
+Use limit orders to avoid that. Limit orders get IB's five minute expiry, and IB cancels a buy limit priced
+further than 10 dollars or 0.25% from the best ask. Short sales are rejected: IB does not lend against
+cryptocurrencies. IB routes API crypto orders from Sunday 03:00 to Friday 16:00 New York time only and holds
+anything placed outside those hours until it reopens, so the brokerage model rejects such orders instead.
+
+Crypto pairs keep the `Market.Coinbase` market, where the backtest data lives, so the same algorithm runs in
+both modes. IB lists only US dollar quoted pairs, recorded as `interactivebrokers` / `crypto` entries of Lean's
+symbol properties database with the tick and lot sizes IB reports, and the brokerage model rejects orders for
+any other pair before they are sent:
+
+    AddCrypto("BTCUSD", Resolution.Minute);
+
+Orders are routed to Paxos, which executes and custodies cryptocurrencies for IB.
 
 ## Downloading Data
 

--- a/interactivebrokers.json
+++ b/interactivebrokers.json
@@ -14,7 +14,7 @@
 		}
 	],
   	"order-types": ["Market", "Limit", "Limit-If-Touched", "Stop Market",  "Stop Limit", "Trailing", "Market On Open", "Market On Close", "Combo Market", "Combo Limit", "Combo Leg Limit", "Exercise"],
-	"assets": ["Equity", "Equity Options", "Futures", "Future Options", "Index Options", "Forex"], 
+	"assets": ["Equity", "Equity Options", "Futures", "Future Options", "Index Options", "Forex", "Crypto"], 
 	"brokerage-url": "https://www.interactivebrokers.com/",
 	"landing-page-url": "/brokerages/interactive",
   	"documentation": "/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers",
@@ -36,6 +36,7 @@
 				"Forex",
 				"Future",
 				"Cfd",
+				"Crypto",
 				"FutureOption",
 				"Index",
 				"IndexOption"
@@ -53,6 +54,7 @@
 				"CFE",
 				"NYSELIFFE",
 				"Oanda",
+				"Coinbase",
 				"InteractiveBrokers"
 			]
 		}


### PR DESCRIPTION
Closes #24. Needs QuantConnect/Lean#9766 and QuantConnect/IBAutomater#114 (IBAutomater 2.0.93).

- CRYPTO contracts on PAXOS; fractional quantities in orders, executions, positions and order status
- market orders are IOC, buys sized by cash (`CashQty`) and closed on IB's own `Filled` status since the filled quantity differs from the requested one; limits get IB's five minute expiry
- AGGTRADES history (TRADES is rejected with 10299); IB's tick sizes from the `interactivebrokers` symbol properties whatever market the symbol is on
- `CryptoOrderHeld` warning on 399: IB routes crypto Sunday 03:00 to Friday 16:00 New York only and holds the rest
- live fixture `InteractiveBrokersCryptoOrderTests`, offline `InteractiveBrokersCryptoTests`

Live tests on paper DU7405806 (crypto trading, no crypto data subscription), Debug build:
- 2026-08-29 21:43 UTC, Saturday: market buy accepted, order confirmation window confirmed by IBAutomater, IB 399 held it until Sunday 03:00 ET; cancel sent, unacknowledged
- 2026-08-30 16:14 UTC `CancelsOpenCryptoOrders`: 0 open, the unacknowledged cancels were applied
- 2026-08-30 16:14 UTC market buy 20 USD (order 50): filled 0.00025289 BTC @ 79085.75 = 19.9999953 USD, `PartiallyFilled` then `Filled` on IB's status; sold 0.00025289 @ 79080.50 (order 51)
- 2026-08-30 16:23 UTC limit buy 0.0002 BTC @ 79093.00 (order 54): 0.00018171 @ 79020.25 + 0.00001829 @ 79093.00; sold 0.0002 @ 79010.75 (order 55)
- paper commission 1% flat, the fee model keeps IB's published 0.18%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
